### PR TITLE
Pull Pojo DTO documentation, report layout and link handling

### DIFF
--- a/doclets/pom.xml
+++ b/doclets/pom.xml
@@ -215,6 +215,32 @@
 							<reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
 						</configuration>
 					</execution>
+					<execution>
+						<id>jaxrs-pojo</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>test-javadoc</goal>
+						</goals>
+						<configuration>
+							<doclet>com.lunatech.doclets.jax.jaxrs.JAXRSDoclet</doclet>
+							<docletPath>:a:${basedir}/target/doclets-${version}.jar</docletPath>
+							<docletArtifacts>
+								<docletArtifact>
+									<groupId>javax.ws.rs</groupId>
+									<artifactId>jsr311-api</artifactId>
+									<version>1.1</version>							
+								</docletArtifact>
+								<docletArtifact>
+									<groupId>org.jboss.resteasy</groupId>
+									<artifactId>resteasy-jaxrs</artifactId>
+									<version>2.0.0.GA</version>
+								</docletArtifact>
+							</docletArtifacts>
+							<destDir>jaxrsdocs-pojo</destDir>
+							<reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
+							<additionalparam>-jaxrscontext rest -disablejavascriptexample -enablepojojson -matchingpojonamesonly com\.lunatech\..*</additionalparam>
+						</configuration>
+					</execution>
 				</executions>
 				<dependencies>
 					<dependency>

--- a/doclets/pom.xml
+++ b/doclets/pom.xml
@@ -238,7 +238,7 @@
 							</docletArtifacts>
 							<destDir>jaxrsdocs-pojo</destDir>
 							<reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
-							<additionalparam>-jaxrscontext rest -disablejavascriptexample -enablepojojson -matchingpojonamesonly com\.lunatech\..*</additionalparam>
+							<additionalparam>-jaxrscontext rest -disablejavascriptexample -enablepojojson -matchingresourcesonly com\.lunatech\..*\.pojo\..* -matchingpojonamesonly com\.lunatech\..*\.pojo\..*</additionalparam>
 						</configuration>
 					</execution>
 				</executions>

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -352,7 +352,7 @@ public class Utils {
   }
 
   public static String urlToClass(ClassDoc from, ClassDoc to) {
-    return classToRoot(from) + classToPath(to) + "/" + to.simpleTypeName() + ".html";
+    return classToRoot(from) + classToPath(to) + "/" + to.name() + ".html";
   }
 
   public static String urlToClass(JAXBClass from, JAXBClass to) {
@@ -516,7 +516,7 @@ public class Utils {
 
   /**
    * Returns either Produces.class or ProduceMime.class (old version)
-   * 
+   *
    * @return
    */
   public static Class<?> getProducesClass() {
@@ -533,7 +533,7 @@ public class Utils {
 
   /**
    * Returns either Consumes.class or ConsumeMime.class (old version)
-   * 
+   *
    * @return
    */
   public static Class<?> getConsumesClass() {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -656,17 +656,21 @@ public class Utils {
     // then the class itself
     if (klass.typeName().equals(typeName))
       return klass;
-    // then go through the named imports
-    for (ClassDoc importedClass : klass.importedClasses()) {
-      if (importedClass.typeName().equals(typeName))
-        return importedClass;
-    }
-    // then the package imports
-    for (PackageDoc importedPackage : klass.importedPackages()) {
-      for (ClassDoc importedClass : importedPackage.allClasses(false)) {
+    try {
+      // then go through the named imports
+      for (ClassDoc importedClass : klass.importedClasses()) {
         if (importedClass.typeName().equals(typeName))
           return importedClass;
       }
+      // then the package imports
+      for (PackageDoc importedPackage : klass.importedPackages()) {
+        for (ClassDoc importedClass : importedPackage.allClasses(false)) {
+          if (importedClass.typeName().equals(typeName))
+            return importedClass;
+        }
+      }
+    } catch (NullPointerException e) {
+
     }
     // now try FQDN
     Type type = doclet.forName(typeName);

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -837,21 +837,25 @@ public class Utils {
     }
   }
 
-  private static String addContextPath(DocletWriter writer, String url) {
+  private static String addContextPath(JAXConfiguration config, String resource) {
     // FIXME: move this to JAXRSConfiguration
-    String jaxrscontext = getOption(writer.getConfiguration().parentConfiguration.root.options(), "-jaxrscontext");
+    String jaxrscontext = getOption(config.parentConfiguration.root.options(), "-jaxrscontext");
     if (jaxrscontext == null)
-      return url;
+      return resource;
     else
-      return appendURLFragments(jaxrscontext, url);
+      return appendURLFragments(jaxrscontext, resource);
   }
 
   public static String getDisplayURL(DocletWriter writer, Resource resource, ResourceMethod method) {
-    return addContextPath(writer, method.getURL(resource));
+    return addContextPath(writer.getConfiguration(), method.getURL(resource));
   }
 
   public static String getAbsolutePath(DocletWriter writer, Resource resource) {
-    return addContextPath(writer, resource.getAbsolutePath());
+    return addContextPath(writer.getConfiguration(), resource.getAbsolutePath());
+  }
+
+  public static String getAbsolutePath(JAXConfiguration config, Resource resource) {
+    return addContextPath(config, resource.getAbsolutePath());
   }
 
   public static void log(String mesg) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -333,6 +333,10 @@ public class Utils {
     return DirectoryManager.getPath(jpaClass.getPackageName());
   }
 
+  public static String classToPath(ClassDoc cDoc) {
+    return DirectoryManager.getPath(cDoc.containingPackage().name());
+  }
+
   public static String urlToPath(Resource resource) {
     String name = resource.getAbsolutePath();
     if (name.startsWith("/"))
@@ -345,6 +349,10 @@ public class Utils {
     if (name.startsWith("/"))
       name = name.substring(1);
     return name.replace('/', File.separatorChar);
+  }
+
+  public static String urlToClass(ClassDoc from, ClassDoc to) {
+    return classToRoot(from) + classToPath(to) + "/" + to.simpleTypeName() + ".html";
   }
 
   public static String urlToClass(JAXBClass from, JAXBClass to) {
@@ -361,6 +369,10 @@ public class Utils {
 
   public static String classToRoot(JAXBClass klass) {
     return DirectoryManager.getRelativePath(klass.getPackageName());
+  }
+
+  public static String classToRoot(ClassDoc cDoc) {
+  	return DirectoryManager.getRelativePath(cDoc.containingPackage());
   }
 
   public static String classToRoot(JPAClass klass) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -840,10 +840,11 @@ public class Utils {
   private static String addContextPath(JAXConfiguration config, String resource) {
     // FIXME: move this to JAXRSConfiguration
     String jaxrscontext = getOption(config.parentConfiguration.root.options(), "-jaxrscontext");
-    if (jaxrscontext == null)
-      return resource;
-    else
+    if (jaxrscontext == null) {
+      return appendURLFragments("/", resource);
+    } else {
       return appendURLFragments(jaxrscontext, resource);
+    }
   }
 
   public static String getDisplayURL(DocletWriter writer, Resource resource, ResourceMethod method) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -175,6 +175,18 @@ public class Utils {
     return null;
   }
 
+  public static AnnotationDesc findAnnotation(final AnnotationDesc[] annotations, final String... soughtAnnotations) {
+    for (final AnnotationDesc annotation : annotations) {
+      final AnnotationTypeDoc annotationType = annotation.annotationType();
+      for (final String soughtAnnotation : soughtAnnotations) {
+        if (annotationType.qualifiedTypeName().equals(soughtAnnotation)) {
+          return annotation;
+        }
+      }
+    }
+    return null;
+  }
+
   public static List<AnnotationDesc> findAnnotations(final AnnotationDesc[] annotations, final Class<?>... soughtAnnotations) {
     List<AnnotationDesc> ret = new LinkedList<AnnotationDesc>();
     for (final AnnotationDesc annotation : annotations) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSConfiguration.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSConfiguration.java
@@ -16,7 +16,9 @@ public class JAXRSConfiguration extends JAXConfiguration {
 
   public boolean enablePojoJsonDataObjects ;
 
-	public Pattern onlyOutputPojosMatching;
+  public Pattern onlyOutputPojosMatching;
+
+  public Pattern onlyOutputResourcesMatching;
 
   public JAXRSConfiguration(ConfigurationImpl conf) {
     super(conf);
@@ -30,10 +32,16 @@ public class JAXRSConfiguration extends JAXConfiguration {
     enableJavaScriptExample = !Utils.hasOption(options, "-disablejavascriptexample");
     enablePojoJsonDataObjects = Utils.hasOption(options, "-enablepojojson");
 
-    String pattern = Utils.getOption(options, "-matchingpojonamesonly");
-    if ((pattern != null) && !pattern.trim().isEmpty()) {
-    	onlyOutputPojosMatching = Pattern.compile(pattern);
+    String jsonPattern = Utils.getOption(options, "-matchingpojonamesonly");
+    if ((jsonPattern != null) && !jsonPattern.trim().isEmpty()) {
+      onlyOutputPojosMatching = Pattern.compile(jsonPattern);
     }
+
+    String resourcePattern = Utils.getOption(options, "-matchingresourcesonly");
+    if ((resourcePattern != null) && !resourcePattern.trim().isEmpty()) {
+      onlyOutputResourcesMatching = Pattern.compile(resourcePattern);
+    }
+
   }
 
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSConfiguration.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSConfiguration.java
@@ -1,5 +1,7 @@
 package com.lunatech.doclets.jax.jaxrs;
 
+import java.util.regex.Pattern;
+
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
 import com.sun.tools.doclets.formats.html.ConfigurationImpl;
@@ -12,6 +14,10 @@ public class JAXRSConfiguration extends JAXConfiguration {
 
   public boolean enableJavaScriptExample;
 
+  public boolean enablePojoJsonDataObjects ;
+
+	public Pattern onlyOutputPojosMatching;
+
   public JAXRSConfiguration(ConfigurationImpl conf) {
     super(conf);
   }
@@ -22,5 +28,12 @@ public class JAXRSConfiguration extends JAXConfiguration {
     jaxrscontext = Utils.getOption(options, "-jaxrscontext");
     enableHTTPExample = !Utils.hasOption(options, "-disablehttpexample");
     enableJavaScriptExample = !Utils.hasOption(options, "-disablejavascriptexample");
+    enablePojoJsonDataObjects = Utils.hasOption(options, "-enablepojojson");
+
+    String pattern = Utils.getOption(options, "-matchingpojonamesonly");
+    if (pattern != null) {
+    	onlyOutputPojosMatching = Pattern.compile(pattern);
+    }
   }
+
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSConfiguration.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSConfiguration.java
@@ -9,7 +9,7 @@ import com.sun.tools.doclets.formats.html.ConfigurationImpl;
 public class JAXRSConfiguration extends JAXConfiguration {
 
   public String jaxrscontext;
-  
+
   public boolean enableHTTPExample;
 
   public boolean enableJavaScriptExample;
@@ -31,7 +31,7 @@ public class JAXRSConfiguration extends JAXConfiguration {
     enablePojoJsonDataObjects = Utils.hasOption(options, "-enablepojojson");
 
     String pattern = Utils.getOption(options, "-matchingpojonamesonly");
-    if (pattern != null) {
+    if ((pattern != null) && !pattern.trim().isEmpty()) {
     	onlyOutputPojosMatching = Pattern.compile(pattern);
     }
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -106,8 +106,8 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     Collections.sort(jaxrsMethods);
     Resource rootResource = Resource.getRootResource(jaxrsMethods);
     rootResource.write(this, conf);
-    new IndexWriter(conf, rootResource).write();
-    new SummaryWriter(conf, rootResource).write();
+    new IndexWriter(conf, rootResource, this).write();
+    new SummaryWriter(conf, rootResource, this).write();
     Utils.copyResources(conf);
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -62,7 +62,8 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
 
   public static int optionLength(final String option) {
     if ("-jaxrscontext".equals(option)
-    		|| "-matchingpojonamesonly".equals(option)) {
+        || "-matchingpojonamesonly".equals(option)
+        || "-matchingresourcesonly".equals(option)) {
       return 2;
     }
     if ("-disablehttpexample".equals(option)
@@ -113,9 +114,9 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
 
     if (conf.enablePojoJsonDataObjects) {
       new DataObjectIndexWriter(conf, app, this, types).write();
-	    for (ClassDoc cDoc : types.getResolvedTypes()) {
+      for (ClassDoc cDoc : types.getResolvedTypes()) {
         new PojoClassWriter(conf, app, cDoc, types, rootResource, this).write();
-	    }
+      }
     }
 
     Utils.copyResources(conf);

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -106,13 +106,14 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     JAXRSApplication app = new JAXRSApplication(conf);
     Resource rootResource = app.getRootResource();
 
-    PojoTypes types = new PojoTypes();
+    PojoTypes types = new PojoTypes(conf);
 
     rootResource.write(this, conf, app, types);
     new IndexWriter(conf, app, this).write();
     new SummaryWriter(conf, app, this).write();
 
     if (conf.enablePojoJsonDataObjects) {
+      types.resolveSubclassDtos();
       new DataObjectIndexWriter(conf, app, this, types).write();
       for (ClassDoc cDoc : types.getResolvedTypes()) {
         new PojoClassWriter(conf, app, cDoc, types, rootResource, this).write();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -19,13 +19,18 @@
 package com.lunatech.doclets.jax.jaxrs;
 
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.ws.rs.Path;
 
 import com.lunatech.doclets.jax.JAXDoclet;
 import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceClass;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
@@ -36,12 +41,15 @@ import com.lunatech.doclets.jax.jaxrs.tags.RequestHeaderTaglet;
 import com.lunatech.doclets.jax.jaxrs.tags.ResponseHeaderTaglet;
 import com.lunatech.doclets.jax.jaxrs.tags.ReturnWrappedTaglet;
 import com.lunatech.doclets.jax.jaxrs.writers.IndexWriter;
+import com.lunatech.doclets.jax.jaxrs.writers.DataObjectIndexWriter;
+import com.lunatech.doclets.jax.jaxrs.writers.PojoClassWriter;
 import com.lunatech.doclets.jax.jaxrs.writers.SummaryWriter;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.DocErrorReporter;
 import com.sun.javadoc.LanguageVersion;
 import com.sun.javadoc.RootDoc;
 import com.sun.javadoc.SourcePosition;
+import com.sun.javadoc.Type;
 import com.sun.tools.doclets.formats.html.ConfigurationImpl;
 import com.sun.tools.doclets.formats.html.HtmlDoclet;
 import com.sun.tools.doclets.internal.toolkit.AbstractDoclet;
@@ -105,9 +113,19 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     }
     Collections.sort(jaxrsMethods);
     Resource rootResource = Resource.getRootResource(jaxrsMethods);
-    rootResource.write(this, conf);
+    PojoTypes types = new PojoTypes();
+
+    rootResource.write(this, conf, types);
     new IndexWriter(conf, rootResource, this).write();
     new SummaryWriter(conf, rootResource, this).write();
+
+    if (conf.enablePojoJsonDataObjects) {
+	    new DataObjectIndexWriter(conf, rootResource, this, types).write();
+	    for (ClassDoc cDoc : types.getResolvedTypes()) {
+    		new PojoClassWriter(conf, cDoc, types, rootResource, this).write();
+	    }
+    }
+
     Utils.copyResources(conf);
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -54,11 +54,13 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
   private static final Class<?>[] jaxrsAnnotations = new Class<?>[] { Path.class };
 
   public static int optionLength(final String option) {
-    if ("-jaxrscontext".equals(option)) {
+    if ("-jaxrscontext".equals(option)
+    		|| "-matchingpojonamesonly".equals(option)) {
       return 2;
     }
     if ("-disablehttpexample".equals(option)
-        || "-disablejavascriptexample".equals(option)) {
+        || "-disablejavascriptexample".equals(option)
+        || "-enablepojojson".equals(option)) {
       return 1;
     }
     return HtmlDoclet.optionLength(option);

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
@@ -94,7 +94,7 @@ public class JAXRSApplication {
   }
 
   static boolean areEqual(MethodDoc m1, MethodDoc m2) {
-    if (!m1.qualifiedName().equals(m2.qualifiedName())) {
+    if (!m1.name().equals(m2.name())) {
       return false;
     }
     Parameter[] p1 = m1.parameters();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
@@ -3,6 +3,7 @@ package com.lunatech.doclets.jax.jaxrs.model;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import javax.ws.rs.Path;
 
@@ -20,11 +21,14 @@ public class JAXRSApplication {
 
   private Resource rootResource;
 
+  private final JAXRSConfiguration conf;
+
   public JAXRSApplication(JAXRSConfiguration conf) {
-    discoverJAXRSResources(conf);
+    this.conf = conf;
+    discoverJAXRSResources();
   }
 
-  private void discoverJAXRSResources(JAXRSConfiguration conf) {
+  private void discoverJAXRSResources() {
     final ClassDoc[] classes = conf.parentConfiguration.root.classes();
     for (final ClassDoc klass : classes) {
       if (Utils.findAnnotatedClass(klass, jaxrsAnnotations) != null) {
@@ -36,6 +40,12 @@ public class JAXRSApplication {
   }
 
   private void handleJAXRSClass(final ClassDoc klass) {
+    if (conf.onlyOutputResourcesMatching != null) {
+      Matcher m = conf.onlyOutputResourcesMatching.matcher(klass.qualifiedTypeName());
+      if(!m.matches()) {
+        return;
+      }
+    }
     jaxrsMethods.addAll(new ResourceClass(klass, null).getMethods());
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
@@ -1,0 +1,117 @@
+package com.lunatech.doclets.jax.jaxrs.model;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.ws.rs.Path;
+
+import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxrs.JAXRSConfiguration;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.MethodDoc;
+import com.sun.javadoc.Parameter;
+
+public class JAXRSApplication {
+
+  private static final Class<?>[] jaxrsAnnotations = new Class<?>[] { Path.class };
+
+  private List<ResourceMethod> jaxrsMethods = new LinkedList<ResourceMethod>();
+
+  private Resource rootResource;
+
+  public JAXRSApplication(JAXRSConfiguration conf) {
+    discoverJAXRSResources(conf);
+  }
+
+  private void discoverJAXRSResources(JAXRSConfiguration conf) {
+    final ClassDoc[] classes = conf.parentConfiguration.root.classes();
+    for (final ClassDoc klass : classes) {
+      if (Utils.findAnnotatedClass(klass, jaxrsAnnotations) != null) {
+        handleJAXRSClass(klass);
+      }
+    }
+    Collections.sort(jaxrsMethods);
+    rootResource = buildRootResource();
+  }
+
+  private void handleJAXRSClass(final ClassDoc klass) {
+    jaxrsMethods.addAll(new ResourceClass(klass, null).getMethods());
+  }
+
+  public Resource getRootResource() {
+    return rootResource;
+  }
+
+  public Resource findResourceClass(ClassDoc cDoc) {
+    return findResourceClass(cDoc, null, rootResource);
+  }
+
+  public Resource findResourceForMethod(ClassDoc cDoc, MethodDoc member) {
+    return findResourceClass(cDoc, member, rootResource);
+  }
+
+  private Resource findResourceClass(ClassDoc cDoc, MethodDoc mDoc, Resource resource) {
+    for (ResourceMethod rMethod : resource.getMethods()) {
+      if (isImplementedBy(cDoc, rMethod.getDeclaringClass())) {
+        if ((mDoc == null) || areEqual(mDoc, rMethod.getMethodDoc())) {
+          return resource;
+        }
+      }
+    }
+    for (Resource subResource : resource.getResources().values()) {
+      Resource match = findResourceClass(cDoc, mDoc, subResource);
+      if (match != null) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  private boolean isImplementedBy(ClassDoc cDoc, ClassDoc declaringClass) {
+    if (declaringClass.qualifiedTypeName().equals(cDoc.qualifiedTypeName())) {
+      return true;
+    }
+    if ((declaringClass.superclass() != null) && isImplementedBy(cDoc, declaringClass.superclass())) {
+      return true;
+    }
+    for (ClassDoc intDoc : declaringClass.interfaces()) {
+      if (isImplementedBy(cDoc, intDoc)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean areEqual(MethodDoc m1, MethodDoc m2) {
+    if (!m1.qualifiedName().equals(m2.qualifiedName())) {
+      return false;
+    }
+    Parameter[] p1 = m1.parameters();
+    Parameter[] p2 = m1.parameters();
+
+    if (p1.length != p2.length) {
+      return false;
+    }
+    for (int i = 0; i < p1.length; i++) {
+      Parameter pi1 = p1[i];
+      Parameter pi2 = p2[i];
+
+      if (!pi1.typeName().equals(pi2.typeName())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private Resource buildRootResource() {
+    Resource rootResource = new Resource("", null);
+    for (ResourceMethod resourceMethod : jaxrsMethods) {
+      rootResource.addResourceMethod(resourceMethod);
+    }
+    // TODO: Avoid/Prune resource paths that have no resource methods (e.g. a
+    // Java resource method with a multi-part path)
+    return rootResource;
+  }
+
+}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
@@ -19,7 +19,16 @@ public class PojoTypes {
   public static Comparator<Type> TYPE_COMPARATOR = new Comparator<Type>() {
 		@Override
     public int compare(Type t0, Type t1) {
-			String qt0 = t0.qualifiedTypeName();
+      if (t0 == t1) {
+        return 0;
+      }
+      if (t0 == null) {
+        return -1;
+      }
+      if (t1 == null) {
+        return 1;
+      }
+      String qt0 = t0.qualifiedTypeName();
       String qt1 = t1.qualifiedTypeName();
       if (qt0 == qt1) {
         return 0;

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
@@ -1,15 +1,21 @@
 package com.lunatech.doclets.jax.jaxrs.model;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 
+import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxrs.JAXRSConfiguration;
 import com.sun.javadoc.Type;
 import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.FieldDoc;
 
 public class PojoTypes {
-  
+
   public static Comparator<Type> TYPE_COMPARATOR = new Comparator<Type>() {
 		@Override
     public int compare(Type t0, Type t1) {
@@ -28,24 +34,100 @@ public class PojoTypes {
     }
   };
 
+  private final JAXRSConfiguration config;
+
+  public PojoTypes(JAXRSConfiguration config) {
+    this.config = config;
+  }
+
   private final Set<ClassDoc> resolvedTypes = new TreeSet<ClassDoc>(TYPE_COMPARATOR);
-  
+
   private final Set<Type> unresolvedTypes = new TreeSet<Type>(TYPE_COMPARATOR);
-  
+
   public Set<ClassDoc> getResolvedTypes() {
   	return Collections.unmodifiableSet(resolvedTypes);
   }
-  
+
   public Set<Type> getUnresolvedTypes() {
   	return Collections.unmodifiableSet(unresolvedTypes);
   }
-  
-  public void addResolvedType(ClassDoc cDoc) {
-  	this.resolvedTypes.add(cDoc);
+
+  public boolean resolveUsedType(Type type) {
+    final ClassDoc cDoc = type.asClassDoc();
+    if (isPojoToDocument(type)) {
+      if (!this.resolvedTypes.contains(cDoc)) {
+        this.resolvedTypes.add(cDoc);
+        System.err.println("Resolved type " + cDoc.qualifiedTypeName());
+        resolveFieldDtos(cDoc);
+      }
+      return true;
+    } else if (cDoc != null) {
+      this.unresolvedTypes.add(cDoc);
+      return false;
+    }
+    return false;
   }
-  
-  public void addUnresolvedType(Type type) {
-  	this.unresolvedTypes.add(type);
+
+  private void resolveFieldDtos(ClassDoc cDoc) {
+    for (FieldDoc fDoc : cDoc.fields(false)) {
+      resolveUsedType(fDoc.type());
+    }
   }
-  
+
+  public void resolveSubclassDtos() {
+    int resolved = this.resolvedTypes.size();
+    while (true) {
+      // Keep checking until we don't find any new types, so we find subclasses
+      // of field types
+      for (final ClassDoc klass : config.parentConfiguration.root.classes()) {
+        resolveSubclassDtos(klass);
+      }
+      if (this.resolvedTypes.size() == resolved) {
+        // No more resolved types discovered
+        break;
+      }
+      resolved = this.resolvedTypes.size();
+    }
+  }
+
+  private void resolveSubclassDtos(ClassDoc potentialSubclass) {
+    final ClassDoc superClass = potentialSubclass.superclass();
+    if (superClass != null) {
+      if (resolvedTypes.contains(superClass)) {
+        resolveUsedType(potentialSubclass);
+      } else {
+        resolveSubclassDtos(superClass);
+      }
+    }
+  }
+
+  public boolean isPojoToDocument(Type type) {
+    if (type.isPrimitive()) {
+      return false;
+    }
+    if (type.asClassDoc() == null) {
+      return false;
+    }
+    if (config.onlyOutputPojosMatching != null) {
+      Matcher m = config.onlyOutputPojosMatching.matcher(type.qualifiedTypeName());
+      return m.matches();
+    }
+    return true;
+  }
+
+  public List<ClassDoc> getSubclasses(ClassDoc cDoc) {
+    List<ClassDoc> subClasses = new ArrayList<ClassDoc>();
+    for (ClassDoc potentialSubclass : this.resolvedTypes) {
+      if (isSubclass(cDoc, potentialSubclass)) {
+        subClasses.add(potentialSubclass);
+      }
+    }
+    return subClasses;
+  }
+
+  private boolean isSubclass(ClassDoc cDoc, ClassDoc potentialSubclass) {
+    ClassDoc superClass = potentialSubclass.superclass();
+    return (superClass != null) && (superClass.qualifiedTypeName().equals(cDoc.qualifiedTypeName()) || isSubclass(cDoc, superClass));
+  }
+
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
@@ -10,6 +10,7 @@ import java.util.regex.Matcher;
 
 import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSConfiguration;
+import com.sun.javadoc.ParameterizedType;
 import com.sun.javadoc.Type;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.FieldDoc;
@@ -63,6 +64,12 @@ public class PojoTypes {
 
   public boolean resolveUsedType(Type type) {
     final ClassDoc cDoc = type.asClassDoc();
+    if (type.asParameterizedType() != null) {
+      for (final Type param : type.asParameterizedType().typeArguments()) {
+        resolveUsedType(param);
+      }
+      // Fall through to process parameterized base type
+    }
     if (isPojoToDocument(type)) {
       if (!this.resolvedTypes.contains(cDoc)) {
         this.resolvedTypes.add(cDoc);
@@ -81,6 +88,8 @@ public class PojoTypes {
     for (FieldDoc fDoc : cDoc.fields(false)) {
       resolveUsedType(fDoc.type());
     }
+    // TODO: Inspect JavaBean property accessor return types as well
+    // (otherwise this will miss any types in those that aren't in the object model).
   }
 
   public void resolveSubclassDtos() {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
@@ -1,0 +1,40 @@
+package com.lunatech.doclets.jax.jaxrs.model;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.sun.javadoc.Type;
+import com.sun.javadoc.ClassDoc;
+
+public class PojoTypes {
+  
+  public static Comparator<Type> TYPE_COMPARATOR = new Comparator<Type>() {
+		@Override
+    public int compare(Type t0, Type t1) {
+			return t0.qualifiedTypeName().compareTo(t1.qualifiedTypeName());
+    }
+  };
+
+  private final Set<ClassDoc> resolvedTypes = new TreeSet<ClassDoc>(TYPE_COMPARATOR);
+  
+  private final Set<Type> unresolvedTypes = new TreeSet<Type>(TYPE_COMPARATOR);
+  
+  public Set<ClassDoc> getResolvedTypes() {
+  	return Collections.unmodifiableSet(resolvedTypes);
+  }
+  
+  public Set<Type> getUnresolvedTypes() {
+  	return Collections.unmodifiableSet(unresolvedTypes);
+  }
+  
+  public void addResolvedType(ClassDoc cDoc) {
+  	this.resolvedTypes.add(cDoc);
+  }
+  
+  public void addUnresolvedType(Type type) {
+  	this.unresolvedTypes.add(type);
+  }
+  
+}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
@@ -13,7 +13,18 @@ public class PojoTypes {
   public static Comparator<Type> TYPE_COMPARATOR = new Comparator<Type>() {
 		@Override
     public int compare(Type t0, Type t1) {
-			return t0.qualifiedTypeName().compareTo(t1.qualifiedTypeName());
+			String qt0 = t0.qualifiedTypeName();
+      String qt1 = t1.qualifiedTypeName();
+      if (qt0 == qt1) {
+        return 0;
+      }
+      if (qt0 == null) {
+        return -1;
+      }
+      if (qt1 == null) {
+        return 1;
+      }
+      return qt0.compareTo(qt1);
     }
   };
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/PojoTypes.java
@@ -73,7 +73,6 @@ public class PojoTypes {
     if (isPojoToDocument(type)) {
       if (!this.resolvedTypes.contains(cDoc)) {
         this.resolvedTypes.add(cDoc);
-        System.err.println("Resolved type " + cDoc.qualifiedTypeName());
         resolveFieldDtos(cDoc);
       }
       return true;

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import javax.ws.rs.DELETE;
@@ -36,6 +37,7 @@ import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
 import com.lunatech.doclets.jax.jaxrs.writers.ResourceWriter;
 import com.sun.javadoc.Doc;
+import com.sun.javadoc.Type;
 
 public class Resource {
 
@@ -161,12 +163,12 @@ public class Resource {
     return fragmentWithNoRegex;
   }
 
-  public void write(JAXRSDoclet doclet, JAXConfiguration configuration) {
+  public void write(JAXRSDoclet doclet, JAXConfiguration configuration, PojoTypes types) {
     ResourceWriter writer = new ResourceWriter(configuration, this, doclet);
-    writer.write();
+    writer.write(types);
     for (String subResourceKey : subResources.keySet()) {
       Resource subResource = subResources.get(subResourceKey);
-      subResource.write(doclet, configuration);
+      subResource.write(doclet, configuration, types);
     }
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -20,10 +20,10 @@ package com.lunatech.doclets.jax.jaxrs.model;
 
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import javax.ws.rs.DELETE;
@@ -37,7 +37,7 @@ import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
 import com.lunatech.doclets.jax.jaxrs.writers.ResourceWriter;
 import com.sun.javadoc.Doc;
-import com.sun.javadoc.Type;
+import com.sun.javadoc.MethodDoc;
 
 public class Resource {
 
@@ -114,14 +114,6 @@ public class Resource {
       return "/";
   }
 
-  public static Resource getRootResource(List<ResourceMethod> resourceMethods) {
-    Resource rootResource = new Resource("", null);
-    for (ResourceMethod resourceMethod : resourceMethods) {
-      rootResource.addResourceMethod(resourceMethod);
-    }
-    return rootResource;
-  }
-
   private void addSubResource(String firstFragment, ResourceMethod resourceMethod) {
     Resource subResource;
     if (subResources.containsKey(firstFragment)) {
@@ -133,7 +125,7 @@ public class Resource {
     subResource.addResourceMethod(resourceMethod);
   }
 
-  private void addResourceMethod(ResourceMethod resourceMethod) {
+  void addResourceMethod(ResourceMethod resourceMethod) {
     String firstFragment = Utils.getFirstURLFragment(resourceMethod.getPath().substring(getAbsolutePath().length()));
     if (firstFragment == null) {
       methods.add(resourceMethod);
@@ -163,12 +155,12 @@ public class Resource {
     return fragmentWithNoRegex;
   }
 
-  public void write(JAXRSDoclet doclet, JAXConfiguration configuration, PojoTypes types) {
-    ResourceWriter writer = new ResourceWriter(configuration, this, doclet);
+  public void write(JAXRSDoclet doclet, JAXConfiguration configuration, JAXRSApplication application, PojoTypes types) {
+    ResourceWriter writer = new ResourceWriter(configuration, application, this, doclet);
     writer.write(types);
     for (String subResourceKey : subResources.keySet()) {
       Resource subResource = subResources.get(subResourceKey);
-      subResource.write(doclet, configuration, types);
+      subResource.write(doclet, configuration, application, types);
     }
   }
 
@@ -205,4 +197,14 @@ public class Resource {
     }
     return strbuf.toString();
   }
+
+  public ResourceMethod findMethod(MethodDoc member) {
+    for (ResourceMethod method : methods) {
+      if (JAXRSApplication.areEqual(method.getMethodDoc(), member)) {
+        return method;
+      }
+    }
+    return null;
+  }
+
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
@@ -108,10 +108,13 @@ public class Resource {
   }
 
   public String getAbsolutePath() {
-    if (parent != null)
+    if (parent != null) {
       return Utils.appendURLFragments(parent.getAbsolutePath(), getName());
-    else
-      return "/";
+    } else {
+      // Suppress the / on root resources, to make it consistent with display of sub-resources
+      // The context path will always be pre-pended to this for display
+      return "";
+    }
   }
 
   private void addSubResource(String firstFragment, ResourceMethod resourceMethod) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceMethod.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceMethod.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -109,6 +109,18 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
     if (methods.isEmpty() && !declaringMethod.returnType().isPrimitive())
       resourceLocator = new ResourceClass(declaringMethod.returnType().asClassDoc(), this);
 
+  }
+
+  public ResourceClass getResourceClass() {
+    return resource;
+  }
+
+  public ClassDoc getDeclaringClass() {
+    return declaringClass;
+  }
+
+  public MethodDoc getMethodDoc() {
+    return method;
   }
 
   public MethodOutput getOutput() {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceMethod.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceMethod.java
@@ -47,6 +47,8 @@ import com.sun.javadoc.FieldDoc;
 import com.sun.javadoc.MethodDoc;
 import com.sun.javadoc.Parameter;
 import com.sun.javadoc.Tag;
+import com.sun.javadoc.Type;
+import com.sun.javadoc.ParameterizedType;
 
 public class ResourceMethod implements Comparable<ResourceMethod> {
 
@@ -106,9 +108,17 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
     setupMethods();
     setupMIMEs();
     // is this a resource locator?
-    if (methods.isEmpty() && !declaringMethod.returnType().isPrimitive())
-      resourceLocator = new ResourceClass(declaringMethod.returnType().asClassDoc(), this);
-
+    if (methods.isEmpty() && !declaringMethod.returnType().isPrimitive()) {
+      // Handle Class style resource locator factory methods
+      Type t = declaringMethod.returnType();
+    	if("java.lang.Class".equals(t.qualifiedTypeName())) {
+        ParameterizedType p = t.asParameterizedType();
+       	 	if (p != null) {
+       	 		t = p.typeArguments()[0];
+       	 	}
+    	}
+       resourceLocator = new ResourceClass(t.asClassDoc(), this);
+    }
   }
 
   public ResourceClass getResourceClass() {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
@@ -64,7 +64,7 @@ public class DataObjectIndexWriter extends DocletWriter {
     printPrelude("Data object index", "Data objects");
 
     Comparator<Type> typeSimpleNameComparator = new Comparator<Type>() {
-			@Override
+      @Override
       public int compare(Type t0, Type t1) {
         return t0.simpleTypeName().compareTo(t1.simpleTypeName());
       }
@@ -105,10 +105,14 @@ public class DataObjectIndexWriter extends DocletWriter {
         around("a title='" + cDoc.qualifiedTypeName() + "' + href='" + writer.relativePath + getLink(cDoc) + "'", cDoc.simpleTypeName());
         ClassDoc superClass = cDoc.superclass();
         if (pojoTypes.getResolvedTypes().contains(superClass)) {
-          open("span class='supertype'");
+          open("span class='typedetail'");
           print(" extends ");
           around("a title='" + superClass.qualifiedTypeName() + "' href='" + writer.relativePath + getLink(superClass) + "'",
               superClass.simpleTypeName());
+          close("span");
+        } else if (cDoc.isEnum()) {
+          open("span class='typedetail'");
+          print(" (Enumeration)");
           close("span");
         }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
@@ -120,7 +120,7 @@ public class DataObjectIndexWriter extends DocletWriter {
   }
 
   static String getLink(final ClassDoc type) {
-  	return Utils.classToPath(type) + "/" + type.simpleTypeName() + ".html";
+    return Utils.classToPath(type) + "/" + type.typeName() + ".html";
   }
 
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
@@ -66,7 +66,7 @@ public class DataObjectIndexWriter extends DocletWriter {
     Comparator<Type> typeSimpleNameComparator = new Comparator<Type>() {
 			@Override
       public int compare(Type t0, Type t1) {
-				return t0.simpleTypeName().compareTo(t1.simpleTypeName());
+        return t0.simpleTypeName().compareTo(t1.simpleTypeName());
       }
     };
     List<Type> resolvedClasses = new ArrayList<Type>(pojoTypes.getResolvedTypes());
@@ -102,9 +102,18 @@ public class DataObjectIndexWriter extends DocletWriter {
       open("tr");
       open("td");
       if (cDoc != null) {
-      	around("a href='" + writer.relativePath + getLink(cDoc) + "'", cDoc.simpleTypeName());
+        around("a title='" + cDoc.qualifiedTypeName() + "' + href='" + writer.relativePath + getLink(cDoc) + "'", cDoc.simpleTypeName());
+        ClassDoc superClass = cDoc.superclass();
+        if (pojoTypes.getResolvedTypes().contains(superClass)) {
+          open("span class='supertype'");
+          print(" extends ");
+          around("a title='" + superClass.qualifiedTypeName() + "' href='" + writer.relativePath + getLink(superClass) + "'",
+              superClass.simpleTypeName());
+          close("span");
+        }
+
       } else {
-      	print(klass.simpleTypeName());
+        print(klass.simpleTypeName());
       }
       close("td");
       open("td");

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
@@ -1,0 +1,125 @@
+/*
+    Copyright 2009 Lunatech Research
+
+    This file is part of jax-doclets.
+
+    jax-doclets is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    jax-doclets is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with jax-doclets.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.lunatech.doclets.jax.jaxrs.writers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import com.lunatech.doclets.jax.JAXConfiguration;
+import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxb.model.JAXBClass;
+import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
+import com.lunatech.doclets.jax.jaxrs.model.Resource;
+import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.Doc;
+import com.sun.javadoc.ProgramElementDoc;
+import com.sun.javadoc.Type;
+import com.sun.javadoc.TypeVariable;
+import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
+import com.sun.tools.doclets.internal.toolkit.util.DirectoryManager;
+
+public class DataObjectIndexWriter extends DocletWriter {
+
+  private PojoTypes pojoTypes;
+
+	public DataObjectIndexWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet, PojoTypes types) {
+    super(configuration, getWriter(configuration), resource, doclet);
+    this.pojoTypes = types;
+  }
+
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration) {
+    try {
+      return new HtmlDocletWriter(configuration.parentConfiguration, "", "objects-index.html", "");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void write() {
+    printPrelude("Overview of JSON data objects", "Data objects");
+
+    Comparator<Type> typeSimpleNameComparator = new Comparator<Type>() {
+			@Override
+      public int compare(Type t0, Type t1) {
+				return t0.simpleTypeName().compareTo(t1.simpleTypeName());
+      }
+    };
+    List<Type> resolvedClasses = new ArrayList<Type>(pojoTypes.getResolvedTypes());
+		Collections.sort(resolvedClasses, typeSimpleNameComparator);
+
+    printClasses(resolvedClasses);
+
+
+		// TODO: Separate section headers for unresolvable types, plus config param
+    // List<Type> unresolvedClasses = new
+    // ArrayList<Type>(pojoTypes.getUnresolvedTypes());
+    // Collections.sort(unresolvedClasses, typeSimpleNameComparator);
+    // printClasses(unresolvedClasses);
+
+    tag("hr");
+    printPostlude("Data objects");
+    writer.flush();
+    writer.close();
+  }
+
+  private void printClasses(Collection<Type> classes) {
+    tag("hr");
+    open("table class='info'");
+    around("caption class='TableCaption'", "Elements");
+    open("tbody");
+    open("tr");
+    around("th class='TableHeader'", "Data Type");
+    around("th class='TableHeader DescriptionHeader'", "Description");
+    close("tr");
+    for (Type klass : classes) {
+    	ClassDoc cDoc = klass.asClassDoc();
+
+      open("tr");
+      open("td");
+      if (cDoc != null) {
+      	around("a href='" + writer.relativePath + getLink(cDoc) + "'", cDoc.simpleTypeName());
+      } else {
+      	print(klass.simpleTypeName());
+      }
+      close("td");
+      open("td");
+      if (cDoc != null) { // && cDoc.firstSentenceTags() != null
+      	writer.printSummaryComment(cDoc);
+      }
+      close("td");
+      close("tr");
+
+    }
+    close("tbody");
+    close("table");
+  }
+
+  static String getLink(final ClassDoc type) {
+  	return Utils.classToPath(type) + "/" + type.simpleTypeName() + ".html";
+  }
+
+}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
@@ -61,7 +61,7 @@ public class DataObjectIndexWriter extends DocletWriter {
   }
 
   public void write() {
-    printPrelude("Overview of JSON data objects", "Data objects");
+    printPrelude("Data object index", "Data objects");
 
     Comparator<Type> typeSimpleNameComparator = new Comparator<Type>() {
 			@Override

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DataObjectIndexWriter.java
@@ -31,6 +31,7 @@ import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxb.model.JAXBClass;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
@@ -46,14 +47,14 @@ public class DataObjectIndexWriter extends DocletWriter {
 
   private PojoTypes pojoTypes;
 
-	public DataObjectIndexWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet, PojoTypes types) {
-    super(configuration, getWriter(configuration), resource, doclet);
+  public DataObjectIndexWriter(JAXConfiguration configuration, JAXRSApplication application, JAXRSDoclet doclet, PojoTypes types) {
+    super(configuration, getWriter(configuration, application), application, application.getRootResource(), doclet);
     this.pojoTypes = types;
   }
 
-  private static HtmlDocletWriter getWriter(JAXConfiguration configuration) {
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, JAXRSApplication application) {
     try {
-      return new HtmlDocletWriter(configuration.parentConfiguration, "", "objects-index.html", "");
+      return new JAXRSHtmlDocletWriter(application, configuration, "", "objects-index.html", "");
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DocletWriter.java
@@ -42,6 +42,9 @@ public class DocletWriter extends com.lunatech.doclets.jax.writers.DocletWriter 
 
   protected void printOtherMenuItems(String selected) {
     printMenuItem("Index", writer.relativePath + "overview-index.html", selected);
+    if (getJAXRSConfiguration().enablePojoJsonDataObjects) {
+    	printMenuItem("Data objects", writer.relativePath + "objects-index.html", selected);
+    }
     printMenuItem("Root resource", writer.relativePath + "index.html", selected);
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DocletWriter.java
@@ -44,6 +44,16 @@ public class DocletWriter extends com.lunatech.doclets.jax.writers.DocletWriter 
     printMenuItem("Index", writer.relativePath + "overview-index.html", selected);
     printMenuItem("Root resource", writer.relativePath + "index.html", selected);
   }
+
+  protected final void printPrelude(final String title, final String selected) {
+    printHeader(title);
+    printMenu(selected, "top");
+  }
+
+  protected final void printPostlude(String selected) {
+    printMenu(selected, "bottom");
+    printFooter();
+  }
   
   public JAXRSConfiguration getJAXRSConfiguration(){
     return (JAXRSConfiguration) configuration;

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/DocletWriter.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -21,6 +21,7 @@ package com.lunatech.doclets.jax.jaxrs.writers;
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.jaxrs.JAXRSConfiguration;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
@@ -30,14 +31,22 @@ public class DocletWriter extends com.lunatech.doclets.jax.writers.DocletWriter 
 
   protected JAXRSDoclet doclet;
 
-  public DocletWriter(JAXConfiguration configuration, HtmlDocletWriter writer, Resource resource, JAXRSDoclet doclet) {
+  protected JAXRSApplication application;
+
+  public DocletWriter(JAXConfiguration configuration, HtmlDocletWriter writer, JAXRSApplication application, Resource resource,
+      JAXRSDoclet doclet) {
     super(configuration, writer);
     this.resource = resource;
     this.doclet = doclet;
+    this.application = application;
   }
 
   public Resource getResource() {
     return resource;
+  }
+
+  public JAXRSApplication getApplication() {
+    return application;
   }
 
   protected void printOtherMenuItems(String selected) {
@@ -57,7 +66,7 @@ public class DocletWriter extends com.lunatech.doclets.jax.writers.DocletWriter 
     printMenu(selected, "bottom");
     printFooter();
   }
-  
+
   public JAXRSConfiguration getJAXRSConfiguration(){
     return (JAXRSConfiguration) configuration;
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/IndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/IndexWriter.java
@@ -22,18 +22,16 @@ import java.io.IOException;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
 import com.sun.javadoc.Doc;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
-public class IndexWriter extends com.lunatech.doclets.jax.writers.DocletWriter {
+public class IndexWriter extends DocletWriter {
 
-  private Resource resource;
-
-  public IndexWriter(JAXConfiguration configuration, Resource resource) {
-    super(configuration, getWriter(configuration));
-    this.resource = resource;
+  public IndexWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration), resource, doclet);
   }
 
   private static HtmlDocletWriter getWriter(JAXConfiguration configuration) {
@@ -111,8 +109,4 @@ public class IndexWriter extends com.lunatech.doclets.jax.writers.DocletWriter {
     printHeader("Resource index");
   }
 
-  protected void printOtherMenuItems(String selected) {
-    printMenuItem("Index", writer.relativePath + "overview-index.html", selected);
-    printMenuItem("Root resource", writer.relativePath + "index.html", selected);
-  }
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/IndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/IndexWriter.java
@@ -45,12 +45,10 @@ public class IndexWriter extends com.lunatech.doclets.jax.writers.DocletWriter {
   }
 
   public void write() {
-    printHeader();
-    printMenu("Index");
+    printPrelude("Resource index", "Index");
     printResources();
     tag("hr");
-    printMenu("Index");
-    printFooter();
+    printPostlude("Index");
     writer.flush();
     writer.close();
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/IndexWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/IndexWriter.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -23,6 +23,7 @@ import java.io.IOException;
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
 import com.sun.javadoc.Doc;
@@ -30,13 +31,13 @@ import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
 public class IndexWriter extends DocletWriter {
 
-  public IndexWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet) {
-    super(configuration, getWriter(configuration), resource, doclet);
+  public IndexWriter(JAXConfiguration configuration, JAXRSApplication application, JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration, application), application, application.getRootResource(), doclet);
   }
 
-  private static HtmlDocletWriter getWriter(JAXConfiguration configuration) {
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, JAXRSApplication application) {
     try {
-      return new HtmlDocletWriter(configuration.parentConfiguration, "", "overview-index.html", "");
+      return new JAXRSHtmlDocletWriter(application, configuration, "", "overview-index.html", "");
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/JAXRSHtmlDocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/JAXRSHtmlDocletWriter.java
@@ -36,7 +36,6 @@ public class JAXRSHtmlDocletWriter extends HtmlDocletWriter {
   public String seeTagToString(SeeTag tag) {
     final ClassDoc cDoc = tag.referencedClass();
     MemberDoc member = tag.referencedMember();
-    System.err.println(cDoc.qualifiedName() + "#" + member + " in " + tag.holder().name() + " -----> ");
 
     Resource res = null;
     String linkText = null;
@@ -54,10 +53,8 @@ public class JAXRSHtmlDocletWriter extends HtmlDocletWriter {
       res = application.findResourceForMethod(cDoc, (MethodDoc) member);
 
       if (res != null) {
-        System.err.println("Found resource " + res.getAbsolutePath());
         ResourceMethod rMethod = res.findMethod((MethodDoc) member);
         if (rMethod != null) {
-          System.err.println("Found method " + rMethod.getMethodDoc().qualifiedName());
           linkText = getDisplayText(res, rMethod);
           hash = rMethod.getMethods().get(0);
         }
@@ -80,7 +77,6 @@ public class JAXRSHtmlDocletWriter extends HtmlDocletWriter {
       if (hash != null) {
         link += "#" + hash;
       }
-      System.err.println(link + " (" + linkText + ") <" + linkTitle + ">");
       return String.format("<tt><a href='%s' title='%s'>%s</a></tt>", link, linkTitle, linkText);
     }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/JAXRSHtmlDocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/JAXRSHtmlDocletWriter.java
@@ -1,0 +1,115 @@
+package com.lunatech.doclets.jax.jaxrs.writers;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import com.lunatech.doclets.jax.JAXConfiguration;
+import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
+import com.lunatech.doclets.jax.jaxrs.model.Resource;
+import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.MemberDoc;
+import com.sun.javadoc.MethodDoc;
+import com.sun.javadoc.SeeTag;
+import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
+
+public class JAXRSHtmlDocletWriter extends HtmlDocletWriter {
+
+  private JAXRSApplication application;
+  private JAXConfiguration config;
+
+  public JAXRSHtmlDocletWriter(JAXRSApplication application, JAXConfiguration config, String s, String s1, String s2)
+      throws IOException {
+    super(config.parentConfiguration, s, s1, s2);
+    this.application = application;
+    this.config = config;
+  }
+
+  /**
+   * Override links to JAX-RS methods to output method + path text and an
+   * appropriate resource page link. POJO DTO pages are generated using the
+   * standard page location conventions, so the default works for them.
+   */
+  @Override
+  public String seeTagToString(SeeTag tag) {
+    final ClassDoc cDoc = tag.referencedClass();
+    MemberDoc member = tag.referencedMember();
+    System.err.println(cDoc.qualifiedName() + "#" + member + " in " + tag.holder().name() + " -----> ");
+
+    Resource res = null;
+    String linkText = null;
+    String hash = null;
+    if (cDoc == null) {
+      return invalidLink(tag, "Unable to locate referenced class " + cDoc.qualifiedName());
+    } else if (member == null) {
+      // Check for a resource class
+      res = application.findResourceClass(cDoc);
+      if (res != null) {
+        linkText = Utils.getAbsolutePath(this.config, res);
+      }
+    } else if (member instanceof MethodDoc) {
+      // Check for a resource method
+      res = application.findResourceForMethod(cDoc, (MethodDoc) member);
+
+      if (res != null) {
+        System.err.println("Found resource " + res.getAbsolutePath());
+        ResourceMethod rMethod = res.findMethod((MethodDoc) member);
+        if (rMethod != null) {
+          System.err.println("Found method " + rMethod.getMethodDoc().qualifiedName());
+          linkText = getDisplayText(res, rMethod);
+          hash = rMethod.getMethods().get(0);
+        }
+      }
+    }
+    if (res != null) {
+      final String linkTitle;
+      if ((tag.label() != null) && !tag.label().trim().isEmpty()) {
+        linkTitle = linkText;
+        linkText = tag.label();
+      } else {
+        linkTitle = "";
+      }
+      String path = Utils.urlToPath(res);
+      if (path.length() == 0) {
+        path = ".";
+      }
+
+      String link = relativePath + path + "/index.html";
+      if (hash != null) {
+        link += "#" + hash;
+      }
+      System.err.println(link + " (" + linkText + ") <" + linkTitle + ">");
+      return String.format("<tt><a href='%s' title='%s'>%s</a></tt>", link, linkTitle, linkText);
+    }
+
+    return super.seeTagToString(tag);
+  }
+
+  private String getDisplayText(Resource resource, ResourceMethod rMethod) {
+    final StringBuilder sb = new StringBuilder();
+    if (!rMethod.isResourceLocator()) {
+      List<String> methods = rMethod.getMethods();
+      for(int i = 0; i < methods.size(); i++) {
+        sb.append(methods.get(i));
+        if (i < (methods.size() - 1)) {
+          sb.append("/");
+        }
+      }
+      sb.append(" ");
+    }
+    sb.append(Utils.getAbsolutePath(this.config, resource));
+    return sb.toString();
+  }
+
+  private String invalidLink(SeeTag tag, String msg) {
+    config.parentConfiguration.root.printError(tag.position(), msg);
+    return "<span class='invalid-link'>" + tag.text() + "</span>";
+  }
+
+  public JAXRSApplication getApplication() {
+    return application;
+  }
+
+}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -399,21 +399,32 @@ public class MethodWriter extends DocletWriter {
         first = false;
       }
     }
-    print("\n");
 
     Map<String, MethodParameter> headerParameters = method.getHeaderParameters();
     if (!headerParameters.isEmpty()) {
-      for (String name : headerParameters.keySet()) {
+      print("\n");
+      Iterator<String> keys = headerParameters.keySet().iterator();
+      while(keys.hasNext()) {
+        String name = keys.next();
         print(name);
-        print(": …\n");
+        print(": …");
+        if (keys.hasNext()) {
+          print("\n");
+        }
       }
     }
     Map<String, MethodParameter> cookieParameters = method.getCookieParameters();
     if (!cookieParameters.isEmpty()) {
-      for (String name : cookieParameters.keySet()) {
+      print("\n");
+      Iterator<String> keys = headerParameters.keySet().iterator();
+      while(keys.hasNext()) {
+        String name = keys.next();
         print("Cookie: ");
         print(name);
-        print("=…\n");
+        print(": …");
+        if (keys.hasNext()) {
+          print("\n");
+        }
       }
     }
 
@@ -429,7 +440,6 @@ public class MethodWriter extends DocletWriter {
         first = false;
       }
     }
-    print("\n");
     close("pre");
   }
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -177,10 +177,11 @@ public class MethodWriter extends DocletWriter {
           doclet.warn("Invalid @returnWrapped type: " + typeName);
           e.printStackTrace();
         }
-        if (returnType != null)
-          printOutputType(returnType.getType(), types);
-        else
+        if (returnType != null) {
+          printOutputType(returnType, types);
+        } else {
           around("tt", escape(typeName));
+        }
         if (output.getOutputDoc(i) != null) {
           print(" - ");
           print(output.getOutputDoc(i));
@@ -282,7 +283,7 @@ public class MethodWriter extends DocletWriter {
         e.printStackTrace();
       }
       if (returnType != null)
-        printOutputType(returnType.getType(), types);
+        printOutputType(returnType, types);
       else
         around("tt", escape(typeName));
     } else {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -104,6 +104,9 @@ public class MethodWriter extends DocletWriter {
     printHTTPCodes();
     printHTTPRequestHeaders();
     printHTTPResponseHeaders();
+
+    printSince(method.getJavaDoc());
+    printSeeAlso(method.getJavaDoc());
     // printSees();
     close("dl");
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -62,21 +62,7 @@ public class MethodWriter extends DocletWriter {
 
   private void printMethod(String httpMethod, PojoTypes types) {
     around("a name='" + httpMethod + "'", "");
-    if(getJAXRSConfiguration().enableHTTPExample
-        || getJAXRSConfiguration().enableJavaScriptExample){
-      open("table class='examples'", "tr");
-      if(getJAXRSConfiguration().enableHTTPExample){
-        open("td");
-        printHTTPExample(httpMethod);
-        close("td");
-      }
-      if(getJAXRSConfiguration().enableJavaScriptExample){
-        open("td");
-        printAPIExample();
-        close("td");
-      }
-      close("tr", "table");
-    }
+    around("h3", httpMethod + " " + Utils.getAbsolutePath(this, resource));
     if (!Utils.isEmptyOrNull(method.getDoc())) {
       open("p");
       print(method.getDoc());
@@ -84,6 +70,26 @@ public class MethodWriter extends DocletWriter {
     }
     printIncludes();
     open("dl");
+    boolean doubleExample = getJAXRSConfiguration().enableHTTPExample
+        && getJAXRSConfiguration().enableJavaScriptExample;
+    if (doubleExample) {
+      open("table class='examples'", "tr");
+      open("td");
+    }
+    if (getJAXRSConfiguration().enableHTTPExample) {
+      printHTTPExample(httpMethod);
+    }
+    if (doubleExample) {
+      close("td");
+      open("td");
+    }
+    if (getJAXRSConfiguration().enableJavaScriptExample) {
+      printAPIExample();
+    }
+    if (doubleExample) {
+      close("td");
+      close("tr", "table");
+    }
     printInput(types);
     printOutput(types);
     printParameters(method.getQueryParameters(), "Query");
@@ -321,7 +327,8 @@ public class MethodWriter extends DocletWriter {
   }
 
   private void printAPIExample() {
-    around("b", "API Example:");
+    around("dt", "API Example:");
+    open("dd");
     /*
      * We are using tt instead of pre to avoid whitespace issues in the doc's
      * first sentence tags that would show up in a pre and would not in a tt.
@@ -344,6 +351,7 @@ public class MethodWriter extends DocletWriter {
     print("});");
     close("tt");
     close("p");
+    close("dd");
   }
 
   private boolean printAPIParameters(Map<String, MethodParameter> parameters, boolean hasOne) {
@@ -374,7 +382,8 @@ public class MethodWriter extends DocletWriter {
   }
 
   private void printHTTPExample(String httpMethod) {
-    around("b", "HTTP Example:");
+    around("dt", "HTTP Example:");
+    open("dd");
     open("pre");
     String absPath = Utils.getAbsolutePath(this, resource);
 
@@ -441,5 +450,6 @@ public class MethodWriter extends DocletWriter {
       }
     }
     close("pre");
+    close("dd");
   }
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -224,9 +224,9 @@ public class MethodWriter extends DocletWriter {
     }
 
     if (link == null) {
-      print(type.qualifiedTypeName());
+      around("span title='" + type.qualifiedTypeName() + "'", type.typeName());
     } else {
-      around("a href='" + link + "'", type.typeName());
+      around("a title='" + type.qualifiedTypeName() + "' + href='" + link + "'", type.typeName());
     }
     ParameterizedType pType = type.asParameterizedType();
     if (pType != null) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -232,9 +232,9 @@ public class MethodWriter extends DocletWriter {
     }
 
     if (link == null) {
-      around("span title='" + type.qualifiedTypeName() + "'", type.typeName());
+      around("span title='" + type.qualifiedTypeName() + "'", type.simpleTypeName());
     } else {
-      around("a title='" + type.qualifiedTypeName() + "' + href='" + link + "'", type.typeName());
+      around("a title='" + type.qualifiedTypeName() + "' + href='" + link + "'", type.simpleTypeName());
     }
     ParameterizedType pType = type.asParameterizedType();
     if (pType != null) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -65,7 +65,7 @@ public class MethodWriter extends DocletWriter {
     around("h3", httpMethod + " " + Utils.getAbsolutePath(this, resource));
     if (!Utils.isEmptyOrNull(method.getDoc())) {
       open("p");
-      print(method.getDoc());
+      writer.printInlineComment(method.getJavaDoc());
       close("p");
     }
     printIncludes();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -221,12 +221,8 @@ public class MethodWriter extends DocletWriter {
       link = Utils.getExternalLink(configuration.parentConfiguration, type, writer);
 
       if ((link == null) && getJAXRSConfiguration().enablePojoJsonDataObjects) {
-        if (isPojoToGenerate(type)) {
-          ClassDoc cDoc = type.asClassDoc();
-          link = Utils.urlToRoot(getResource()) + DataObjectIndexWriter.getLink(cDoc);
-          types.addResolvedType(cDoc);
-        } else {
-          types.addUnresolvedType(type);
+        if (types.resolveUsedType(type)) {
+          link = Utils.urlToRoot(getResource()) + DataObjectIndexWriter.getLink(type.asClassDoc());
         }
       }
     }
@@ -251,18 +247,6 @@ public class MethodWriter extends DocletWriter {
       print("&gt;");
     }
     print(type.dimension());
-  }
-
-  private boolean isPojoToGenerate(Type type) {
-    JAXRSConfiguration jaxrsConfiguration = getJAXRSConfiguration();
-    if (type.asClassDoc() == null) {
-      return false;
-    }
-    if (jaxrsConfiguration.onlyOutputPojosMatching != null) {
-      Matcher m = jaxrsConfiguration.onlyOutputPojosMatching.matcher(type.qualifiedTypeName());
-      return m.matches();
-    }
-    return true;
   }
 
   private void printInput(PojoTypes types) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -31,6 +31,7 @@ import com.lunatech.doclets.jax.Utils.InvalidJaxTypeException;
 import com.lunatech.doclets.jax.Utils.JaxType;
 import com.lunatech.doclets.jax.jaxrs.JAXRSConfiguration;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.MethodOutput;
 import com.lunatech.doclets.jax.jaxrs.model.MethodParameter;
 import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
@@ -49,8 +50,8 @@ public class MethodWriter extends DocletWriter {
 
   private ResourceMethod method;
 
-  public MethodWriter(ResourceMethod method, ResourceWriter resourceWriter, JAXRSDoclet doclet) {
-    super(resourceWriter.getConfiguration(), resourceWriter.getWriter(), resourceWriter.getResource(), doclet);
+  public MethodWriter(ResourceMethod method, ResourceWriter resourceWriter, JAXRSDoclet doclet, JAXRSApplication application) {
+    super(resourceWriter.getConfiguration(), resourceWriter.getWriter(), application, resourceWriter.getResource(), doclet);
     this.method = method;
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -74,7 +74,7 @@ public class PojoClassWriter extends DocletWriter {
   private void printSummary() {
     open("h2 class='classname'");
     around("span class='name'", "Data object: " + cDoc.simpleTypeName());
-    around("span class='namespace'", "(" + cDoc.containingPackage().name() + ")");
+    around("span class='namespace'", "(in " + getContainer() + ")");
     close("h2");
     Doc javaDoc = cDoc;
     if (javaDoc.tags() != null) {
@@ -85,6 +85,10 @@ public class PojoClassWriter extends DocletWriter {
     // printJSONExample();
     // close("td");
     // close("tr", "table");
+  }
+
+  private String getContainer() {
+    return (cDoc.containingClass() == null) ? cDoc.containingPackage().name() : cDoc.containingClass().qualifiedTypeName();
   }
 
   private void printMembers(FieldDoc[] fieldDocs, String title) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -111,7 +111,7 @@ public class PojoClassWriter extends DocletWriter {
       open("td");
       Doc javaDoc = member;
       if (javaDoc.firstSentenceTags() != null)
-        writer.printSummaryComment(javaDoc);
+        writer.printInlineComment(javaDoc);
       close("td");
       close("tr");
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -29,6 +29,7 @@ import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
 import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
+import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.Doc;
 import com.sun.javadoc.FieldDoc;
@@ -163,7 +164,15 @@ public class PojoClassWriter extends DocletWriter {
     // TODO: This won't cope with any of the more esoteric Jackson strategies for mapping properties (including auto-detection strategies)
     if (method.name().startsWith("get")
         || (method.name().startsWith("is") && method.returnType().simpleTypeName().equalsIgnoreCase("boolean"))) {
+      // Jackson @JsonIgnore
+      final AnnotationDesc jsonIgnore = Utils.findAnnotation(method.annotations(),
+          "org.codehaus.jackson.annotate.JsonIgnore",
+          "com.fasterxml.jackson.annotation.JsonIgnore");
+      if (jsonIgnore == null || Boolean.FALSE.equals(Utils.getAnnotationValue(jsonIgnore))) {
         return true;
+      } else {
+        System.err.println(method.qualifiedName() + " is @JsonIgnored");
+      }
     }
     return false;
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -66,7 +66,13 @@ public class PojoClassWriter extends DocletWriter {
   }
 
   public void write() {
-    printPrelude("Data object: " + cDoc.typeName(), "");
+    final String objectType;
+    if (cDoc.isEnum()) {
+      objectType = "Enumeration";
+    } else {
+      objectType = "Data object";
+    }
+    printPrelude(objectType + ": " + cDoc.typeName(), "");
     printSummary();
     printElements();
     tag("hr");
@@ -76,12 +82,24 @@ public class PojoClassWriter extends DocletWriter {
   }
 
   private void printElements() {
+    if (cDoc.isEnum()) {
+      printEnumConstants();
+    } else {
       printProperties(properties, "Properties");
+    }
   }
+
 
   private void printSummary() {
     open("h2 class='classname'");
-    around("span class='name'", "Data object: " + cDoc.simpleTypeName());
+    // TODO: Factor this
+    final String objectType;
+    if (cDoc.isEnum()) {
+      objectType = "Enumeration";
+    } else {
+      objectType = "Data object";
+    }
+    around("span class='name'", objectType + ": " + cDoc.simpleTypeName());
     around("span class='namespace'", "(in " + getContainer() + ")");
     close("h2");
 
@@ -161,6 +179,34 @@ public class PojoClassWriter extends DocletWriter {
       return Character.toLowerCase(basename.charAt(0)) + basename.substring(1);
     }
     return memberName;
+  }
+
+  private void printEnumConstants() {
+    tag("hr");
+    open("table class='info' id='EnumConstants'");
+    around("caption class='TableCaption'", "Enum Constants");
+    open("tbody");
+    open("tr");
+
+    around("th class='TableHeader'", "Constant");
+    around("th class='TableHeader DescriptionHeader'", "Description");
+    close("tr");
+    for (final FieldDoc enumConst : cDoc.enumConstants()) {
+      open("tr");
+      open("td id='ec_" + enumConst.name() + "'");
+      print(enumConst.name());
+      close("td");
+      open("td");
+      Doc javaDoc = enumConst;
+      if (!Utils.isEmptyOrNull(javaDoc.commentText())) {
+        writer.printInlineComment(javaDoc);
+      }
+      close("td");
+      close("tr");
+
+    }
+    close("tbody");
+    close("table");
   }
 
   private void printProperties(PropertyDoc[] propertyDocs, String title) {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -50,7 +50,7 @@ public class PojoClassWriter extends DocletWriter {
 
   private static HtmlDocletWriter getWriter(JAXConfiguration configuration, JAXRSApplication application, ClassDoc cDoc) {
     try {
-      return new JAXRSHtmlDocletWriter(application, configuration, Utils.classToPath(cDoc), cDoc.simpleTypeName()
+      return new JAXRSHtmlDocletWriter(application, configuration, Utils.classToPath(cDoc), cDoc.typeName()
           + ".html", Utils.classToRoot(cDoc));
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -58,7 +58,7 @@ public class PojoClassWriter extends DocletWriter {
   }
 
   public void write() {
-  	printPrelude("Data object: " + cDoc.simpleTypeName(), "");
+    printPrelude("Data object: " + cDoc.typeName(), "");
     printSummary();
     printElements();
     tag("hr");
@@ -132,15 +132,13 @@ public class PojoClassWriter extends DocletWriter {
   	if (type.isPrimitive() || type.qualifiedTypeName().startsWith("java.lang")) {
   		print(type.simpleTypeName());
   	} else {
-  		ClassDoc fDoc = type.asClassDoc();
-  		if (fDoc == null || fDoc.qualifiedName().equals(cDoc.qualifiedName())
-  				|| !this.pojoTypes.getResolvedTypes().contains(fDoc)) {
-  			around("span title='" + type.qualifiedTypeName() + "'", type.typeName());
-  		} else {
-  			around("a title='" + fDoc.qualifiedTypeName() + "' href='"
-  					   + Utils.urlToClass(cDoc, fDoc) + "'", fDoc.typeName());
-  		}
-  	}
+      ClassDoc fDoc = type.asClassDoc();
+      if (fDoc == null || fDoc.qualifiedName().equals(cDoc.qualifiedName()) || !this.pojoTypes.getResolvedTypes().contains(fDoc)) {
+        around("span title='" + type.qualifiedTypeName() + "'", type.simpleTypeName());
+      } else {
+        around("a title='" + fDoc.qualifiedTypeName() + "' href='" + Utils.urlToClass(cDoc, fDoc) + "'", fDoc.simpleTypeName());
+      }
+    }
     ParameterizedType pType = type.asParameterizedType();
     if (pType != null) {
       boolean first = true;

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -105,6 +105,9 @@ public class PojoClassWriter extends DocletWriter {
     around("th class='TableHeader DescriptionHeader'", "Description");
     close("tr");
     for (FieldDoc member : fieldDocs) {
+      if (member.isStatic()) {
+        continue;
+      }
       open("tr");
 	    open("td id='m_" + member.name() + "'");
 	    print(member.name());

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -19,6 +19,7 @@
 package com.lunatech.doclets.jax.jaxrs.writers;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
@@ -76,6 +77,31 @@ public class PojoClassWriter extends DocletWriter {
     around("span class='name'", "Data object: " + cDoc.simpleTypeName());
     around("span class='namespace'", "(in " + getContainer() + ")");
     close("h2");
+
+    ClassDoc superClass = cDoc.superclass();
+    if (pojoTypes.getResolvedTypes().contains(superClass)) {
+      open("dl class='supertype'");
+      around("dt", "Supertype:");
+      open("dd");
+      around("a title='" + superClass.qualifiedTypeName() + "' href='" + Utils.urlToClass(cDoc, superClass) + "'",
+          superClass.simpleTypeName());
+      close("dd", "dl");
+    }
+    List<ClassDoc> subClasses = pojoTypes.getSubclasses(cDoc);
+    if (!subClasses.isEmpty()) {
+      open("dl class='subtypes'");
+      around("dt", "Known sub-types:");
+      open("dd");
+      for (int i = 0; i < subClasses.size(); i++) {
+        ClassDoc scDoc = subClasses.get(i);
+        around("a title='" + scDoc.qualifiedTypeName() + "' href='" + Utils.urlToClass(cDoc, scDoc) + "'", scDoc.simpleTypeName());
+        if (i < (subClasses.size() - 1)) {
+          print(",");
+        }
+      }
+      close("dd", "dl");
+    }
+
     Doc javaDoc = cDoc;
     if (javaDoc.tags() != null) {
       writer.printInlineComment(javaDoc);

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -36,6 +36,8 @@ import com.sun.javadoc.FieldDoc;
 import com.sun.javadoc.MemberDoc;
 import com.sun.javadoc.MethodDoc;
 import com.sun.javadoc.ParameterizedType;
+import com.sun.javadoc.SeeTag;
+import com.sun.javadoc.Tag;
 import com.sun.javadoc.Type;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
@@ -92,7 +94,7 @@ public class PojoClassWriter extends DocletWriter {
 
 
   private void printSummary() {
-    open("h2 class='classname'");
+    open("h2 class='pojosummary'");
     // TODO: Factor this
     final String objectType;
     if (cDoc.isEnum()) {
@@ -132,11 +134,11 @@ public class PojoClassWriter extends DocletWriter {
     if (javaDoc.tags() != null) {
       writer.printInlineComment(javaDoc);
     }
-    // open("table class='examples'", "tr");
-    // open("td");
-    // printJSONExample();
-    // close("td");
-    // close("tr", "table");
+    // @since
+    printSince(javaDoc);
+
+    // @see tags
+    printSeeAlso(javaDoc);
   }
 
   private String getContainer() {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -135,7 +135,7 @@ public class PojoClassWriter extends DocletWriter {
   }
 
   private void printMemberTypeGeneric(Type type) {
-  	System.err.println("Type : " + type.qualifiedTypeName());
+    // System.err.println("Type : " + type.qualifiedTypeName());
   	if (type.isPrimitive() || type.qualifiedTypeName().startsWith("java.lang")) {
   		print(type.simpleTypeName());
   	} else {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -19,23 +19,15 @@
 package com.lunatech.doclets.jax.jaxrs.writers;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Set;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
-import com.lunatech.doclets.jax.jaxb.JAXBConfiguration;
-import com.lunatech.doclets.jax.jaxb.model.Attribute;
-import com.lunatech.doclets.jax.jaxb.model.Element;
-import com.lunatech.doclets.jax.jaxb.model.JAXBClass;
-import com.lunatech.doclets.jax.jaxb.model.JAXBMember;
-import com.lunatech.doclets.jax.jaxb.model.MemberType;
-import com.lunatech.doclets.jax.jaxb.model.Value;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
-import com.sun.javadoc.Doc;
 import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.Doc;
 import com.sun.javadoc.FieldDoc;
 import com.sun.javadoc.ParameterizedType;
 import com.sun.javadoc.Type;
@@ -49,16 +41,17 @@ public class PojoClassWriter extends DocletWriter {
 
 	private PojoTypes pojoTypes;
 
-  public PojoClassWriter(JAXConfiguration configuration, ClassDoc cDoc, PojoTypes types, Resource resource, JAXRSDoclet doclet) {
-    super(configuration, getWriter(configuration, cDoc), resource, doclet);
+  public PojoClassWriter(JAXConfiguration configuration, JAXRSApplication application, ClassDoc cDoc, PojoTypes types, Resource resource,
+      JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration, application, cDoc), application, resource, doclet);
     this.cDoc = cDoc;
     this.pojoTypes = types;
   }
 
-  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, ClassDoc cDoc) {
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, JAXRSApplication application, ClassDoc cDoc) {
     try {
-      return new HtmlDocletWriter(configuration.parentConfiguration, Utils.classToPath(cDoc), cDoc.simpleTypeName() + ".html",
-          Utils.classToRoot(cDoc));
+      return new JAXRSHtmlDocletWriter(application, configuration, Utils.classToPath(cDoc), cDoc.simpleTypeName()
+          + ".html", Utils.classToRoot(cDoc));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/PojoClassWriter.java
@@ -1,0 +1,170 @@
+/*
+    Copyright 2009 Lunatech Research
+
+    This file is part of jax-doclets.
+
+    jax-doclets is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    jax-doclets is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with jax-doclets.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.lunatech.doclets.jax.jaxrs.writers;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+
+import com.lunatech.doclets.jax.JAXConfiguration;
+import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxb.JAXBConfiguration;
+import com.lunatech.doclets.jax.jaxb.model.Attribute;
+import com.lunatech.doclets.jax.jaxb.model.Element;
+import com.lunatech.doclets.jax.jaxb.model.JAXBClass;
+import com.lunatech.doclets.jax.jaxb.model.JAXBMember;
+import com.lunatech.doclets.jax.jaxb.model.MemberType;
+import com.lunatech.doclets.jax.jaxb.model.Value;
+import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
+import com.lunatech.doclets.jax.jaxrs.model.Resource;
+import com.sun.javadoc.Doc;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.FieldDoc;
+import com.sun.javadoc.ParameterizedType;
+import com.sun.javadoc.Type;
+import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
+
+public class PojoClassWriter extends DocletWriter {
+
+  public static final String ZERO_OR_N = "zero or N[";
+
+  private final ClassDoc cDoc;
+
+	private PojoTypes pojoTypes;
+
+  public PojoClassWriter(JAXConfiguration configuration, ClassDoc cDoc, PojoTypes types, Resource resource, JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration, cDoc), resource, doclet);
+    this.cDoc = cDoc;
+    this.pojoTypes = types;
+  }
+
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, ClassDoc cDoc) {
+    try {
+      return new HtmlDocletWriter(configuration.parentConfiguration, Utils.classToPath(cDoc), cDoc.simpleTypeName() + ".html",
+          Utils.classToRoot(cDoc));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void write() {
+  	printPrelude("Data object: " + cDoc.simpleTypeName(), "");
+    printSummary();
+    printElements();
+    tag("hr");
+    printPostlude("");
+    writer.flush();
+    writer.close();
+  }
+
+  private void printElements() {
+    printMembers(cDoc.fields(false), "Fields");
+  }
+
+  private void printSummary() {
+    open("h2 class='classname'");
+    around("span class='name'", "Data object: " + cDoc.simpleTypeName());
+    around("span class='namespace'", "(" + cDoc.containingPackage().name() + ")");
+    close("h2");
+    Doc javaDoc = cDoc;
+    if (javaDoc.tags() != null) {
+      writer.printInlineComment(javaDoc);
+    }
+    // open("table class='examples'", "tr");
+    // open("td");
+    // printJSONExample();
+    // close("td");
+    // close("tr", "table");
+  }
+
+  private void printMembers(FieldDoc[] fieldDocs, String title) {
+    if (fieldDocs.length == 0)
+      return;
+    tag("hr");
+    open("table class='info' id='" + title + "'");
+    around("caption class='TableCaption'", title);
+    open("tbody");
+    open("tr");
+
+    around("th class='TableHeader'", "Name");
+    around("th class='TableHeader'", "Type");
+    around("th class='TableHeader DescriptionHeader'", "Description");
+    close("tr");
+    for (FieldDoc member : fieldDocs) {
+      open("tr");
+	    open("td id='m_" + member.name() + "'");
+	    print(member.name());
+	    close("td");
+      open("td");
+      printMemberType(member);
+      close("td");
+      open("td");
+      Doc javaDoc = member;
+      if (javaDoc.firstSentenceTags() != null)
+        writer.printSummaryComment(javaDoc);
+      close("td");
+      close("tr");
+
+    }
+    close("tbody");
+    close("table");
+  }
+
+  private void printMemberType(FieldDoc field) {
+    open("tt");
+    final Type type = field.type();
+    printMemberTypeGeneric(type);
+    close("tt");
+  }
+
+  private void printMemberTypeGeneric(Type type) {
+  	System.err.println("Type : " + type.qualifiedTypeName());
+  	if (type.isPrimitive() || type.qualifiedTypeName().startsWith("java.lang")) {
+  		print(type.simpleTypeName());
+  	} else {
+  		ClassDoc fDoc = type.asClassDoc();
+  		if (fDoc == null || fDoc.qualifiedName().equals(cDoc.qualifiedName())
+  				|| !this.pojoTypes.getResolvedTypes().contains(fDoc)) {
+  			around("span title='" + type.qualifiedTypeName() + "'", type.typeName());
+  		} else {
+  			around("a title='" + fDoc.qualifiedTypeName() + "' href='"
+  					   + Utils.urlToClass(cDoc, fDoc) + "'", fDoc.typeName());
+  		}
+  	}
+    ParameterizedType pType = type.asParameterizedType();
+    if (pType != null) {
+      boolean first = true;
+      print("&lt;");
+      for (Type genericType : pType.typeArguments()) {
+        if (first) {
+          first = false;
+        } else {
+          print(",");
+        }
+        printMemberTypeGeneric(genericType);
+      }
+      print("&gt;");
+    }
+    print(type.dimension());
+
+  }
+
+
+}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -21,14 +21,17 @@ package com.lunatech.doclets.jax.jaxrs.writers;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
 import com.lunatech.doclets.jax.jaxrs.model.MethodParameter;
+import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
 import com.sun.javadoc.Doc;
+import com.sun.javadoc.Type;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
 public class ResourceWriter extends DocletWriter {
@@ -46,24 +49,19 @@ public class ResourceWriter extends DocletWriter {
     }
   }
 
-  public void write() {
+  public void write(PojoTypes types) {
     boolean isRoot = resource.getParent() == null;
     String selected = isRoot ? "Root resource" : "";
     printPrelude(isRoot, selected);
     printResourceInfo();
     printSubresources();
-    printMethods();
+    if (resource.hasRealMethods()) {
+      printMethodOverview(resource.getMethods());
+      printMethodDetails(resource.getMethods(), types);
+    }
     tag("hr");
     printPostlude(selected);
     writer.flush();
-  }
-
-  private void printMethods() {
-    if (!resource.hasRealMethods())
-      return;
-    List<ResourceMethod> methods = resource.getMethods();
-    printMethodOverview(methods);
-    printMethodDetails(methods);
   }
 
   private void printMethodOverview(List<ResourceMethod> methods) {
@@ -98,7 +96,7 @@ public class ResourceWriter extends DocletWriter {
     close("table");
   }
 
-  private void printMethodDetails(List<ResourceMethod> methods) {
+  private void printMethodDetails(List<ResourceMethod> methods, PojoTypes types) {
     tag("hr");
     open("table class='info' id='methods-details'");
     around("caption class='TableCaption'", "Method Detail");
@@ -110,7 +108,7 @@ public class ResourceWriter extends DocletWriter {
         continue;
       open("tr");
       open("td");
-      new MethodWriter(method, this, doclet).print();
+      new MethodWriter(method, this, doclet).print(types);
       close("td");
       close("tr");
     }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -49,14 +49,12 @@ public class ResourceWriter extends DocletWriter {
   public void write() {
     boolean isRoot = resource.getParent() == null;
     String selected = isRoot ? "Root resource" : "";
-    printHeader(isRoot);
-    printMenu(selected);
+    printPrelude(isRoot, selected);
     printResourceInfo();
     printSubresources();
     printMethods();
     tag("hr");
-    printMenu(selected);
-    printFooter();
+    printPostlude(selected);
     writer.flush();
   }
 
@@ -245,11 +243,11 @@ public class ResourceWriter extends DocletWriter {
 
   }
 
-  private void printHeader(boolean isRoot) {
+  private void printPrelude(boolean isRoot, String selected) {
     if (isRoot)
-      printHeader("Root Resource");
+      printPrelude("Root Resource", selected);
     else
-      printHeader("Resource " + resource.getName());
+      printPrelude("Resource " + resource.getName(), selected);
   }
 
   protected void printThirdMenu() {

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -53,10 +53,14 @@ public class ResourceWriter extends DocletWriter {
     boolean isRoot = resource.getParent() == null;
     String selected = isRoot ? "Root resource" : "";
     printPrelude(isRoot, selected);
+    open("dl");
     printResourceInfo();
     printSubresources();
     if (resource.hasRealMethods()) {
       printMethodOverview(resource.getMethods());
+    }
+    close("dl");
+    if (resource.hasRealMethods()) {
       printMethodDetails(resource.getMethods(), types);
     }
     tag("hr");
@@ -66,11 +70,15 @@ public class ResourceWriter extends DocletWriter {
 
   private void printMethodOverview(List<ResourceMethod> methods) {
     tag("hr");
+    open("dt");
+    print("Resource Methods");
+    close("dt");
+    open("dd");
     open("table class='info' id='methods-summary'");
     around("caption class='TableCaption'", "Method Summary");
     open("tbody");
     open("tr");
-    around("th class='TableHeader'", "Resource");
+    around("th class='TableHeader'", "Name");
     around("th class='TableHeader'", "Description");
     close("tr");
     for (ResourceMethod method : methods) {
@@ -94,6 +102,7 @@ public class ResourceWriter extends DocletWriter {
     }
     close("tbody");
     close("table");
+    close("dd");
   }
 
   private void printMethodDetails(List<ResourceMethod> methods, PojoTypes types) {
@@ -121,6 +130,10 @@ public class ResourceWriter extends DocletWriter {
     if (resources.isEmpty())
       return;
     tag("hr");
+    open("dt");
+    print("Sub-Resources");
+    close("dt");
+    open("dd");
     open("table class='info' id='resources'");
     around("caption class='TableCaption'", "Resources");
     open("tbody");
@@ -155,6 +168,7 @@ public class ResourceWriter extends DocletWriter {
     }
     close("tbody");
     close("table");
+    close("dd");
   }
 
   private Resource deepFilter(Resource resource) {
@@ -221,7 +235,6 @@ public class ResourceWriter extends DocletWriter {
       Map<String, MethodParameter> parameters = rm.getPathParameters();
       for (MethodParameter param : parameters.values()) {
         if (needsPathHeading) {
-          open("dl");
           open("dt");
           around("b", "Path parameters:");
           close("dt");
@@ -237,7 +250,6 @@ public class ResourceWriter extends DocletWriter {
         close("dd");
       }
       if (!needsPathHeading) {
-        close("dl");
       }
     } while (false);
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -21,29 +21,28 @@ package com.lunatech.doclets.jax.jaxrs.writers;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.MethodParameter;
 import com.lunatech.doclets.jax.jaxrs.model.PojoTypes;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
 import com.sun.javadoc.Doc;
-import com.sun.javadoc.Type;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
 public class ResourceWriter extends DocletWriter {
 
-  public ResourceWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet) {
-    super(configuration, getWriter(configuration, resource), resource, doclet);
+  public ResourceWriter(JAXConfiguration configuration, JAXRSApplication application, Resource resource, JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration, application, resource), application, resource, doclet);
   }
 
-  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, Resource resource) {
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, JAXRSApplication application, Resource resource) {
     String pathName = Utils.urlToSystemPath(resource);
     try {
-      return new HtmlDocletWriter(configuration.parentConfiguration, pathName, "index.html", Utils.urlToRoot(resource));
+      return new JAXRSHtmlDocletWriter(application, configuration, pathName, "index.html", Utils.urlToRoot(resource));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -117,7 +116,7 @@ public class ResourceWriter extends DocletWriter {
         continue;
       open("tr");
       open("td");
-      new MethodWriter(method, this, doclet).print(types);
+      new MethodWriter(method, this, doclet, application).print(types);
       close("td");
       close("tr");
     }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -203,10 +203,12 @@ public class ResourceWriter extends DocletWriter {
     else
       print(buf.toString());
     close("h2");
+    open("div class='doc-comment'");
     Doc javaDoc = this.resource.getJavaDoc();
     if (javaDoc != null && javaDoc.tags() != null) {
       writer.printInlineComment(javaDoc);
     }
+    close("div");
     do {
       boolean needsPathHeading = true;
       List<ResourceMethod> lrm = this.resource.getMethods();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/SummaryWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/SummaryWriter.java
@@ -46,12 +46,10 @@ public class SummaryWriter extends com.lunatech.doclets.jax.writers.DocletWriter
   }
 
   public void write() {
-    printHeader();
-    printMenu("Overview");
+    printPrelude("Overview of resources", "Overview");
     printResources();
     tag("hr");
-    printMenu("Overview");
-    printFooter();
+    printPostlude("Overview");
     writer.flush();
     writer.close();
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/SummaryWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/SummaryWriter.java
@@ -23,18 +23,16 @@ import java.util.Map;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
+import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
 import com.sun.javadoc.Doc;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
-public class SummaryWriter extends com.lunatech.doclets.jax.writers.DocletWriter {
+public class SummaryWriter extends DocletWriter {
 
-  private Resource resource;
-
-  public SummaryWriter(JAXConfiguration configuration, Resource resource) {
-    super(configuration, getWriter(configuration));
-    this.resource = resource;
+  public SummaryWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration), resource, doclet);
   }
 
   private static HtmlDocletWriter getWriter(JAXConfiguration configuration) {
@@ -115,8 +113,4 @@ public class SummaryWriter extends com.lunatech.doclets.jax.writers.DocletWriter
     printHeader("Overview of resources");
   }
 
-  protected void printOtherMenuItems(String selected) {
-    printMenuItem("Index", writer.relativePath + "overview-index.html", selected);
-    printMenuItem("Root resource", writer.relativePath + "index.html", selected);
-  }
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/SummaryWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/SummaryWriter.java
@@ -1,6 +1,6 @@
 /*
     Copyright 2009 Lunatech Research
-    
+
     This file is part of jax-doclets.
 
     jax-doclets is free software: you can redistribute it and/or modify
@@ -24,6 +24,7 @@ import java.util.Map;
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.JAXRSDoclet;
+import com.lunatech.doclets.jax.jaxrs.model.JAXRSApplication;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
 import com.sun.javadoc.Doc;
@@ -31,13 +32,13 @@ import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
 public class SummaryWriter extends DocletWriter {
 
-  public SummaryWriter(JAXConfiguration configuration, Resource resource, JAXRSDoclet doclet) {
-    super(configuration, getWriter(configuration), resource, doclet);
+  public SummaryWriter(JAXConfiguration configuration, JAXRSApplication application, JAXRSDoclet doclet) {
+    super(configuration, getWriter(configuration, application), application, application.getRootResource(), doclet);
   }
 
-  private static HtmlDocletWriter getWriter(JAXConfiguration configuration) {
+  private static HtmlDocletWriter getWriter(JAXConfiguration configuration, JAXRSApplication application) {
     try {
-      return new HtmlDocletWriter(configuration.parentConfiguration, "", "overview-summary.html", "");
+      return new JAXRSHtmlDocletWriter(application, configuration, "", "overview-summary.html", "");
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
@@ -110,7 +110,11 @@ public class DocletWriter {
   }
 
   protected void printMenu(String selected) {
-    open("table class='menu'", "colgroup");
+  	printMenu(selected, null);
+  }
+
+  protected void printMenu(String selected, String subStyle) {
+    open("table class='menu " + (subStyle != null ? "menu-" + subStyle : "") + "'", "colgroup");
     tag("col", "col");
     close("colgroup");
     open("tbody", "tr");

--- a/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
@@ -20,6 +20,9 @@ package com.lunatech.doclets.jax.writers;
 
 import com.lunatech.doclets.jax.JAXConfiguration;
 import com.lunatech.doclets.jax.Utils;
+import com.sun.javadoc.Doc;
+import com.sun.javadoc.SeeTag;
+import com.sun.javadoc.Tag;
 import com.sun.tools.doclets.formats.html.HtmlDocletWriter;
 
 public class DocletWriter {
@@ -159,4 +162,33 @@ public class DocletWriter {
   protected String escape(String str) {
     return str.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
   }
+
+  protected void printSeeAlso(Doc javaDoc) {
+    SeeTag[] seeTags = javaDoc.seeTags();
+    if ((seeTags != null) && (seeTags.length > 0)) {
+      open("dl class='seealso'");
+      around("dt", "See Also:");
+      open("dd");
+      for (int i = 0; i < seeTags.length; i++) {
+        SeeTag seeTag = seeTags[i];
+        writer.printSummaryComment(javaDoc, new SeeTag[] { seeTag });
+        if (i < (seeTags.length - 1)) {
+          writer.write(", ");
+        }
+      }
+      close("dd", "dl");
+    }
+  }
+
+  protected void printSince(Doc javaDoc) {
+    Tag[] sinceTags = javaDoc.tags("since");
+    if ((sinceTags != null) && (sinceTags.length > 0)) {
+      open("dl class='since'");
+      around("dt", "Since:");
+      open("dd");
+      writer.write(sinceTags[0].text());
+      close("dd", "dl");
+    }
+  }
+
 }

--- a/doclets/src/main/resources/doclet.css
+++ b/doclets/src/main/resources/doclet.css
@@ -120,7 +120,7 @@ table.examples pre {
 
 /* Pojo */
 
-span.supertype {
+span.typedetail {
  position:relative;
  top: 0.1em;
  font-size:smaller;

--- a/doclets/src/main/resources/doclet.css
+++ b/doclets/src/main/resources/doclet.css
@@ -117,3 +117,11 @@ table.examples pre {
  height: 800px;
  border: 1px solid black;
 }
+
+/* Pojo */
+
+span.supertype {
+ position:relative;
+ top: 0.1em;
+ font-size:smaller;
+}

--- a/doclets/src/main/resources/doclet.css
+++ b/doclets/src/main/resources/doclet.css
@@ -125,3 +125,10 @@ span.typedetail {
  top: 0.1em;
  font-size:smaller;
 }
+
+dl.subtypes dt,
+dl.supertype dt,
+dl.since dt,
+dl.seealso dt {
+	font-weight: bold;
+}

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/RESTOrdersBean.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/RESTOrdersBean.java
@@ -115,8 +115,21 @@ public class RESTOrdersBean implements RESTOrders {
     Open, Closed;
   }
 
+  /**
+   * A comment.
+   *
+   * More information may be contained in an {@link ExtraComment}
+   * 
+   */
   @XmlRootElement
   public static class Comment {}
+
+  /**
+   * An extension to {@link Comment} that adds extra comment.
+   *
+   */
+  @XmlRootElement
+  public static class ExtraComment extends Comment {}
 
   @XmlRootElement
   public static class Attachment {

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/interfaces/RESTOrders.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/interfaces/RESTOrders.java
@@ -68,8 +68,11 @@ public interface RESTOrders {
   public Response getOrders(@QueryParam("creator") String creatorKey, @QueryParam("filter") final String filter);
 
   /**
-   * Adds a new order
+   * Adds a new order.
    * 
+   * To list existing orders, use the {@link #getOrders(String, String) listing
+   * resource}
+   *
    * @param newOrder
    *          the new order to add
    * @HTTP 201 When created
@@ -95,8 +98,11 @@ public interface RESTOrders {
   // Order
 
   /**
-   * The order resource
-   * 
+   * The order resource.
+   *
+   * This can be used to obtain an order, or multiple orders can be obtained
+   * using {@link #getOrders(String, String)}.
+   *
    * @param orderKey
    *          the order key
    * @return the order found

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/Ingredient.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/Ingredient.java
@@ -9,6 +9,10 @@ package com.lunatech.doclets.jax.test.pojo;
  * <p>
  * Or maybe you needed to look at {@link PojoRESTPizza#aResourceMethodThatDoesntExist()}
  * 
+ * @see PojoPizza
+ * @see PojoRESTPizza
+ * @see PojoRESTPizza#getPojoPizza(String)
+ * @since 1.2
  */
 public class Ingredient {
 

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/Ingredient.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/Ingredient.java
@@ -2,6 +2,12 @@ package com.lunatech.doclets.jax.test.pojo;
 
 /**
  * General type for pizza ingredients.
+ * <p>
+ * Maybe you want {@link APizzaIngredientThatDoesntExist}.
+ * <p>
+ * Or maybe you want to look at {@link Ingredient#aMethodThatDoesntExist()}
+ * <p>
+ * Or maybe you needed to look at {@link PojoRESTPizza#aResourceMethodThatDoesntExist()}
  * 
  */
 public class Ingredient {

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/Ingredient.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/Ingredient.java
@@ -1,0 +1,22 @@
+package com.lunatech.doclets.jax.test.pojo;
+
+/**
+ * General type for pizza ingredients.
+ * 
+ */
+public class Ingredient {
+
+  private boolean fresh;
+
+  /**
+   * Is the ingredient fresh?
+   */
+  public boolean isFresh() {
+    return fresh;
+  }
+
+  public void setFresh(boolean fresh) {
+    this.fresh = fresh;
+  }
+
+}

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PizzaStyle.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PizzaStyle.java
@@ -1,0 +1,23 @@
+package com.lunatech.doclets.jax.test.pojo;
+
+/**
+ * Crust style.
+ */
+public enum PizzaStyle {
+
+  /** Thin and crispy */
+  THIN_CRUST,
+
+  /** Classic pan */
+  DEEP_DISH,
+
+  /** Heart attack stuff */
+  CHEEZE_STUFFED,
+
+  /** Apparently served in Dubai */
+  SAUSAGE_STUFFED,
+
+  /** Local specialty */
+  BURNT
+
+}

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PojoPizza.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PojoPizza.java
@@ -1,0 +1,64 @@
+package com.lunatech.doclets.jax.test.pojo;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A plainer style of Pizza.
+ * 
+ */
+public class PojoPizza {
+
+    private PizzaStyle style;
+
+    private Date expirationDate;
+
+    private List<Ingredient> ingredients;
+
+    private String name;
+
+    /**
+     * The pizza style, choose with care.
+     */
+    public PizzaStyle getStyle() {
+      return style;
+    }
+
+    public void setStyle(PizzaStyle style) {
+      this.style = style;
+    }
+
+    /**
+     * Bah, who needs that?
+     */
+    public Date getExpirationDate() {
+      return expirationDate;
+    }
+
+    public void setExpirationDate(Date expirationDate) {
+      this.expirationDate = expirationDate;
+    }
+
+    /**
+     * The list of ingredients.
+     */
+    public List<Ingredient> getIngredients() {
+      return ingredients;
+    }
+
+    public void setIngredients(List<Ingredient> ingredients) {
+      this.ingredients = ingredients;
+    }
+
+    /**
+     * The pizza name.
+     */
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+}

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PojoRESTPizza.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PojoRESTPizza.java
@@ -22,6 +22,10 @@ public class PojoRESTPizza {
    * The PojoPizzas resource
    *
    * @return the list of all the PojoPizzas matching the query
+   * @see PojoPizza
+   * @see PojoRESTPizza
+   * @see PojoRESTPizza#getPojoPizza(String)
+   * @since 1.2
    */
   @GET
   public List<PojoPizza> getPojoPizzas(@Form Query query) {

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PojoRESTPizza.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/PojoRESTPizza.java
@@ -1,0 +1,46 @@
+package com.lunatech.doclets.jax.test.pojo;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import org.jboss.resteasy.annotations.Form;
+
+import com.lunatech.doclets.jax.test.demo.doc.Query;
+
+@Consumes({ "application/ingredient" })
+@Produces({ "application/PojoPizza" })
+@Path("/plainPojoPizzas")
+public class PojoRESTPizza {
+
+  /**
+   * The PojoPizzas resource
+   *
+   * @return the list of all the PojoPizzas matching the query
+   */
+  @GET
+  public List<PojoPizza> getPojoPizzas(@Form Query query) {
+    // retrieve PojoPizzas
+    return Collections.emptyList();
+  }
+
+  /**
+   * The PojoPizza resource
+   *
+   * @param name
+   *          the name of the PojoPizza to find
+   * @return the PojoPizza with the given name
+   * @HTTP 404 Sent when the PojoPizza doesn't exist.
+   */
+  @GET
+  @Path("{name}")
+  public PojoPizza getPojoPizza(@PathParam("name") String name) {
+    // fetch PojoPizza
+    return new PojoPizza();
+  }
+}

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/TomatoIngredient.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/TomatoIngredient.java
@@ -1,5 +1,8 @@
 package com.lunatech.doclets.jax.test.pojo;
 
+/**
+ * Red stuff
+ */
 public class TomatoIngredient extends Ingredient {
 
   private String variety;

--- a/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/TomatoIngredient.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/test/pojo/TomatoIngredient.java
@@ -1,0 +1,18 @@
+package com.lunatech.doclets.jax.test.pojo;
+
+public class TomatoIngredient extends Ingredient {
+
+  private String variety;
+
+  /**
+   * The variety of the tomatoes used.
+   */
+  public String getVariety() {
+    return variety;
+  }
+
+  public void setVariety(String variety) {
+    this.variety = variety;
+  }
+
+}

--- a/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
+++ b/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
@@ -10,7 +10,7 @@ JavaDoc is used. Documentation for a given RESTful URL is taken from the method 
 {{@HEAD}}, {{@POST}}, {{@PUT}} or {{@DELETE}}
 for that URL (in order of preference).
 
-JAX-RS resource locators are supported.
+JAX-RS resource locators, including Class factory resource locators (resource locator methods with a {{Class<?>}} return type) are supported.
 
 {note}Since the JAX-RS supports links to JAXB documentation, you should first run the JAXB doclet, then
 the JAX-RS doclet using the [{{-link}}|#-link] parameter.{note}

--- a/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
+++ b/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
@@ -64,3 +64,25 @@ If the optional RESTEasy dependency is present,
 the following RESTEasy annotations are supported on resource methods or classes:
 
 * {{@Form}}
+
+h2. POJO Mapping
+
+Some JAX-RS frameworks (e.g. Jersey) support the use of POJO style JSON serialization/deserialization.
+To support this, the JAX-RS doclet provides a POJO JSON documentation mode (enabled using the {{-pojojson}} configuration option, and associated configuration options). 
+
+When POJO JSON documentation mode is enabled, the objects used in resource methods will be documented as POJO objects, unless they are already documented in linked documentation (e.g. standard Java types, or JAXB Doclet documentation).
+
+The following items are documented:
+* DTO object types (including linking in JavaDoc)
+* JavaBean style properties
+* Generic and parameter types (used in properties or as type parameters in DTO types)
+* Enumerated types
+* Subclasses of DTO object types (polymorphic DTOs)
+
+A separate Data objects page is added to the top level menu when POJO JSON documentation mode is enabled.
+
+h3. Supported Jackson Features
+
+In the POJO JSON documentation mode, the following annotations will be detected on property accessors, and will suppress documentation for that property:
+* {{org.codehaus.jackson.annotate.JsonIgnore}} (Jackson 1.x)
+* {{com.fasterxml.jackson.annotation.JsonIgnore}} (Jackson 2.x)

--- a/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
+++ b/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
@@ -22,6 +22,14 @@ The following standard JavaDoc tags are supported on resource methods:
 ||Tag||Function||
 |{{@param \{name\} \{doc\} }}|This is used to document the corresponding resource method parameters annotated with {{@PathParam}}, {{@QueryParam}} or {{@MatrixParam}}. Can be used at most once per parameter name.|
 |{{@return \{doc\} }}|Documents the entity returned from this resource method. Can only be used once.|
+|{{@link \{DTO/resource class/resource class#method\} }} | Inline linking to DTO objects, resources and resource methods to be linked to. |
+
+h2. Linking in JAX-RS JavaDoc
+
+The following types of {{@link}} links are supported:
+* Links to a DTO object type - 
+* Links to a resource class - produces a link to the resource summary, with the resource URL as the link text (e.g. {{/rest/resource}}).
+* Links to a resource method - produces a link to the resource method summary, with the resource method and URL as the link text (e.g. {{GET /rest/resource}}).
 
 h2. Supported specific JavaDoc tags
 

--- a/docs/src/main/wikbook/en/en-US/running.wiki
+++ b/docs/src/main/wikbook/en/en-US/running.wiki
@@ -267,5 +267,5 @@ a:visited {
 }
 {code}
 
-Note that wherever possible we´ve stuck with the JavaDoc CSS class names so you can reuse your 
+Note that wherever possible we've stuck with the JavaDoc CSS class names so you can reuse your 
 existing JavaDoc stylesheets.

--- a/docs/src/main/wikbook/en/en-US/running.wiki
+++ b/docs/src/main/wikbook/en/en-US/running.wiki
@@ -220,7 +220,12 @@ These parameters are only valid for the JAX-RS doclet
 |{{-jaxrscontext url}}|The URL path to your RESTful API, if there is a prefix prepended to it on your deploy site.|
 |{{-disablehttpexample}}|Disables the generated HTTP examples.|
 |{{-disablejavascriptexample}}|Disables the generated JavaScript examples.|
+|{{-enablepojojson}}|Enables the POJO JSON documentation mode.|
 |{{-matchingresourcesonly}}|A regular expression specifying the types of resource classes (based on the fully qualified type name) that will be documented. Useful when sharing resource classes or DTOs between projects. \\ Defaults to matching all resource classes.|
+
+These parameters are only valid when the POJO JSON documentation mode is enabled
+||Parameter||Function||
+|{{-matchingpojonamesonly}}|A regular expression specifying the types (based on the fully qualified type name) that will be documented with the POJO JSON documentation mode. \\ Defaults to all used types. |
 
 h3. JAXB doclet parameters
 

--- a/docs/src/main/wikbook/en/en-US/running.wiki
+++ b/docs/src/main/wikbook/en/en-US/running.wiki
@@ -220,6 +220,7 @@ These parameters are only valid for the JAX-RS doclet
 |{{-jaxrscontext url}}|The URL path to your RESTful API, if there is a prefix prepended to it on your deploy site.|
 |{{-disablehttpexample}}|Disables the generated HTTP examples.|
 |{{-disablejavascriptexample}}|Disables the generated JavaScript examples.|
+|{{-matchingresourcesonly}}|A regular expression specifying the types of resource classes (based on the fully qualified type name) that will be documented. Useful when sharing resource classes or DTOs between projects. \\ Defaults to matching all resource classes.|
 
 h3. JAXB doclet parameters
 


### PR DESCRIPTION
We've been making some local improvements to the JAX-RS doclet to handle our setup (POJO style Jackson serialization) and improve the produced reports. 

Notably:
- Optionally generate documentation pages for DTOs referenced in resource methods after the resource methods are resolved
- @link tags are now supported in documentation on resource methods, linking to resource classes or resource methods
- The resource layout has been modified to make it more visually consistent/clear (this may not be to your liking, as we use a custom CSS as well)

I've done one pull request so you can have a look at the improvements to date, but let me know if you want it chunked up a bit finer.
