### PR TITLE
Make HTML more valid and support -nonavbar option

### DIFF
--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -105,7 +105,6 @@ public class ResourceWriter extends DocletWriter {
     open("table class='info' id='methods-details'");
     around("caption class='TableCaption'", "Method Detail");
     open("tbody");
-    close("tr");
     for (ResourceMethod method : methods) {
       // skip resource locator methods
       if (method.isResourceLocator())

--- a/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
@@ -110,15 +110,17 @@ public class DocletWriter {
   }
 
   protected void printMenu(String selected) {
-    open("table class='menu'", "colgroup");
-    tag("col", "col");
-    close("colgroup");
-    open("tbody", "tr");
-    open("td class='NavBarCell1' colspan='2'");
-    printTopMenu(selected);
-    close("td", "tr");
-    printThirdMenu();
-    close("table");
+    if(!configuration.parentConfiguration.nonavbar) {
+      open("table class='menu'", "colgroup");
+      tag("col", "col");
+      close("colgroup");
+      open("tbody", "tr");
+      open("td class='NavBarCell1' colspan='2'");
+      printTopMenu(selected);
+      close("td", "tr");
+      printThirdMenu();
+      close("table");
+    }
   }
 
   protected void printThirdMenu() {}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
@@ -76,10 +76,10 @@ public class DocletWriter {
   }
 
   protected void printHeader(String title) {
+    open("!DOCTYPE html");
     open("HTML");
     open("HEAD");
     around("TITLE", title);
-    close("TITLE");
     tag("LINK REL='stylesheet' TYPE='text/css' HREF='" + writer.relativePath + "doclet.css' TITLE='Style'");
     String charset = configuration.parentConfiguration.charset;
     if (Utils.isEmptyOrNull(charset))

--- a/docs/src/main/wikbook/en/en-US/running.wiki
+++ b/docs/src/main/wikbook/en/en-US/running.wiki
@@ -211,6 +211,7 @@ These parameters are valid for all jax-doclets
 |{{-footer}}|The footer which is inserted on every page footer.|
 |{{-charset}}|The charset to use for source files and produced HTML documentation.|
 |{{-link}}{anchor:id=-link}|Path to another JavaDoc documentation. This is used to produce links to other package's documentation, either regular JavaDoc or to JAXB documentation in the case of the JAX-RS doclet.|
+|{{-nonavbar}}|Prevents the generation of the navigation bar.|
 
 h3. JAX-RS doclet parameters
 


### PR DESCRIPTION
These changes:
- Remove some extraneous tags (extra </title> and </tr)
- Add a doctype (HTML5)
- Don't print the nav bar if [-nonavbar](http://docs.oracle.com/javase/1.4.2/docs/tooldocs/windows/javadoc.html#nonavbar) is passed

It's still not completely valid HTML since apparently &lt;tt&gt; isn't supported anymore, but it's closer.
