### PR TITLE
Print parameter documentation in the order its defined in

### DIFF
--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -101,6 +101,9 @@ public class Utils {
   }
 
   public static MethodDoc findAnnotatedMethod(final ClassDoc declaringClass, final MethodDoc method, final Class<?>... soughtAnnotations) {
+    if(isExcluded(method)) {
+        return null;
+    }
     final AnnotationDesc onMethod = findAnnotation(method, soughtAnnotations);
     if (onMethod != null) {
       return method;
@@ -193,7 +196,7 @@ public class Utils {
     final Type[] interfaceTypes = klass.interfaceTypes();
     for (final Type interfaceType : interfaceTypes) {
       final ClassDoc interfaceClassDoc = interfaceType.asClassDoc();
-      if (interfaceClassDoc != null) {
+      if (interfaceClassDoc != null && !isExcluded(interfaceClassDoc)) {
         if (hasAnnotation(interfaceClassDoc, soughtAnnotations)) {
           return interfaceClassDoc;
         }
@@ -207,7 +210,7 @@ public class Utils {
   }
 
   public static ClassDoc findAnnotatedClass(final ClassDoc klass, final Class<?>... soughtAnnotations) {
-    if (!klass.isClass())
+    if (!klass.isClass() || isExcluded(klass))
       return null;
     if (hasAnnotation(klass, soughtAnnotations)) {
       return klass;
@@ -840,5 +843,9 @@ public class Utils {
 
   public static void log(String mesg) {
     // System.err.println(mesg);
+  }
+
+  private static boolean isExcluded(Doc doc) {
+      return doc.tags("exclude").length != 0;
   }
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -274,7 +274,7 @@ public class Utils {
   }
 
   public static String appendURLFragments(String... fragments) {
-    StringBuffer strbuf = new StringBuffer();
+    StringBuilder strbuf = new StringBuilder();
     for (String fragment : fragments) {
       // skip empty fragments
       if (fragment == null || fragment.length() == 0)
@@ -381,7 +381,7 @@ public class Utils {
     if (from == null || from.length() == 0) {
       return "";
     }
-    StringBuffer pathstr = new StringBuffer();
+    StringBuilder pathstr = new StringBuilder();
     for (int i = 0; i < from.length(); i++) {
       char ch = from.charAt(i);
       if (ch == '/') {
@@ -397,14 +397,8 @@ public class Utils {
       return;
     }
     File dir = new File(path);
-    if (dir.exists()) {
-      return;
-    } else {
-      if (dir.mkdirs()) {
-        return;
-      } else {
-        throw new RuntimeException("Could not create path: " + path);
-      }
+    if (!dir.exists() && !dir.mkdirs()) {
+      throw new RuntimeException("Could not create path: " + path);
     }
   }
 

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -19,8 +19,8 @@
 package com.lunatech.doclets.jax.jaxrs;
 
 import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.ws.rs.Path;
 
@@ -67,7 +67,7 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     return AbstractDoclet.languageVersion();
   }
 
-  private List<ResourceMethod> jaxrsMethods = new LinkedList<ResourceMethod>();
+  private Set<ResourceMethod> jaxrsMethods = new TreeSet<ResourceMethod>();
 
   public static boolean start(final RootDoc rootDoc) {
     new JAXRSDoclet(rootDoc).start();
@@ -97,7 +97,6 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
         handleJAXRSClass(klass);
       }
     }
-    Collections.sort(jaxrsMethods);
     Resource rootResource = Resource.getRootResource(jaxrsMethods);
     rootResource.write(this, conf);
     new IndexWriter(conf, rootResource).write();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -19,7 +19,7 @@
 package com.lunatech.doclets.jax.jaxrs;
 
 import java.util.Collections;
-import java.util.Collection;
+import java.util.List;
 import java.util.LinkedList;
 
 import javax.ws.rs.Path;
@@ -67,7 +67,7 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     return AbstractDoclet.languageVersion();
   }
 
-  private Collection<ResourceMethod> jaxrsMethods = new LinkedList<ResourceMethod>();
+  private List<ResourceMethod> jaxrsMethods = new LinkedList<ResourceMethod>();
 
   public static boolean start(final RootDoc rootDoc) {
     new JAXRSDoclet(rootDoc).start();
@@ -97,6 +97,7 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
         handleJAXRSClass(klass);
       }
     }
+    Collections.sort(this.jaxrsMethods);
     Resource rootResource = Resource.getRootResource(jaxrsMethods);
     rootResource.write(this, conf);
     new IndexWriter(conf, rootResource).write();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -29,12 +29,7 @@ import com.lunatech.doclets.jax.Utils;
 import com.lunatech.doclets.jax.jaxrs.model.Resource;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceClass;
 import com.lunatech.doclets.jax.jaxrs.model.ResourceMethod;
-import com.lunatech.doclets.jax.jaxrs.tags.HTTPTaglet;
-import com.lunatech.doclets.jax.jaxrs.tags.IncludeTaglet;
-import com.lunatech.doclets.jax.jaxrs.tags.InputWrappedTaglet;
-import com.lunatech.doclets.jax.jaxrs.tags.RequestHeaderTaglet;
-import com.lunatech.doclets.jax.jaxrs.tags.ResponseHeaderTaglet;
-import com.lunatech.doclets.jax.jaxrs.tags.ReturnWrappedTaglet;
+import com.lunatech.doclets.jax.jaxrs.tags.*;
 import com.lunatech.doclets.jax.jaxrs.writers.IndexWriter;
 import com.lunatech.doclets.jax.jaxrs.writers.SummaryWriter;
 import com.sun.javadoc.ClassDoc;
@@ -87,6 +82,7 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     htmlDoclet.configuration.tagletManager.addCustomTag(new LegacyTaglet(new ReturnWrappedTaglet()));
     htmlDoclet.configuration.tagletManager.addCustomTag(new LegacyTaglet(new InputWrappedTaglet()));
     htmlDoclet.configuration.tagletManager.addCustomTag(new LegacyTaglet(new IncludeTaglet()));
+    htmlDoclet.configuration.tagletManager.addCustomTag(new ExcludeTaglet());
   }
 
   @Override

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/JAXRSDoclet.java
@@ -19,8 +19,8 @@
 package com.lunatech.doclets.jax.jaxrs;
 
 import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.Collection;
+import java.util.LinkedList;
 
 import javax.ws.rs.Path;
 
@@ -67,7 +67,7 @@ public class JAXRSDoclet extends JAXDoclet<JAXRSConfiguration> {
     return AbstractDoclet.languageVersion();
   }
 
-  private Set<ResourceMethod> jaxrsMethods = new TreeSet<ResourceMethod>();
+  private Collection<ResourceMethod> jaxrsMethods = new LinkedList<ResourceMethod>();
 
   public static boolean start(final RootDoc rootDoc) {
     new JAXRSDoclet(rootDoc).start();

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
@@ -19,6 +19,7 @@
 package com.lunatech.doclets.jax.jaxrs.model;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -112,7 +113,7 @@ public class Resource {
       return "/";
   }
 
-  public static Resource getRootResource(List<ResourceMethod> resourceMethods) {
+  public static Resource getRootResource(Collection<ResourceMethod> resourceMethods) {
     Resource rootResource = new Resource("", null);
     for (ResourceMethod resourceMethod : resourceMethods) {
       rootResource.addResourceMethod(resourceMethod);

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/Resource.java
@@ -146,8 +146,7 @@ public class Resource {
     for (ResourceMethod method : methods) {
       dump(offset + 1, "+ [M]" + method.toString());
     }
-    for (String subResourceKey : subResources.keySet()) {
-      Resource subResource = subResources.get(subResourceKey);
+    for (Resource subResource : subResources.values()) {
       subResource.dump(offset + 1);
     }
   }
@@ -165,8 +164,7 @@ public class Resource {
   public void write(JAXRSDoclet doclet, JAXConfiguration configuration) {
     ResourceWriter writer = new ResourceWriter(configuration, this, doclet);
     writer.write();
-    for (String subResourceKey : subResources.keySet()) {
-      Resource subResource = subResources.get(subResourceKey);
+    for (Resource subResource : subResources.values()) {
       subResource.write(doclet, configuration);
     }
   }
@@ -180,8 +178,6 @@ public class Resource {
   }
 
   public boolean hasRealMethods() {
-    if (methods.isEmpty())
-      return false;
     for (ResourceMethod method : methods) {
       if (!method.isResourceLocator())
         return true;
@@ -194,7 +190,7 @@ public class Resource {
   }
 
   public String getPathFrom(Resource parent) {
-    StringBuffer strbuf = new StringBuffer();
+    StringBuilder strbuf = new StringBuilder();
     Resource resource = this;
     while (resource != parent) {
       strbuf.insert(0, resource.getName());

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceMethod.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceMethod.java
@@ -47,6 +47,7 @@ import com.sun.javadoc.FieldDoc;
 import com.sun.javadoc.MethodDoc;
 import com.sun.javadoc.Parameter;
 import com.sun.javadoc.Tag;
+import java.util.Arrays;
 
 public class ResourceMethod implements Comparable<ResourceMethod> {
 
@@ -64,17 +65,17 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
 
   private MethodDoc method;
 
-  final Map<String, MethodParameter> pathParameters = new HashMap<String, MethodParameter>();
+  final List<MethodParameter> pathParameters = new ArrayList<MethodParameter>();
 
-  final Map<String, MethodParameter> matrixParameters = new HashMap<String, MethodParameter>();
+  final List<MethodParameter> matrixParameters = new ArrayList<MethodParameter>();
 
-  final Map<String, MethodParameter> queryParameters = new HashMap<String, MethodParameter>();
+  final List<MethodParameter> queryParameters = new ArrayList<MethodParameter>();
 
-  final Map<String, MethodParameter> headerParameters = new HashMap<String, MethodParameter>();
+  final List<MethodParameter> headerParameters = new ArrayList<MethodParameter>();
 
-  final Map<String, MethodParameter> cookieParameters = new HashMap<String, MethodParameter>();
+  final List<MethodParameter> cookieParameters = new ArrayList<MethodParameter>();
 
-  final Map<String, MethodParameter> formParameters = new HashMap<String, MethodParameter>();
+  final List<MethodParameter> formParameters = new ArrayList<MethodParameter>();
 
   private List<AnnotationDesc> methods = new LinkedList<AnnotationDesc>();
 
@@ -141,40 +142,37 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
       final AnnotationDesc pathParamAnnotation = Utils.findParameterAnnotation(declaringMethod, parameter, i, PathParam.class);
       if (pathParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(pathParamAnnotation);
-        pathParameters.put(name, new RealMethodParameter(parameter, i, pathParamAnnotation, MethodParameterType.Path, declaringMethod));
+        pathParameters.add(new RealMethodParameter(parameter, i, pathParamAnnotation, MethodParameterType.Path, declaringMethod));
         continue;
       }
       final AnnotationDesc matrixParamAnnotation = Utils.findParameterAnnotation(declaringMethod, parameter, i, MatrixParam.class);
       if (matrixParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(matrixParamAnnotation);
-        matrixParameters.put(name,
-                             new RealMethodParameter(parameter, i, matrixParamAnnotation, MethodParameterType.Matrix, declaringMethod));
+        matrixParameters.add(new RealMethodParameter(parameter, i, matrixParamAnnotation, MethodParameterType.Matrix, declaringMethod));
         continue;
       }
       final AnnotationDesc queryParamAnnotation = Utils.findParameterAnnotation(declaringMethod, parameter, i, QueryParam.class);
       if (queryParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(queryParamAnnotation);
-        queryParameters.put(name, new RealMethodParameter(parameter, i, queryParamAnnotation, MethodParameterType.Query, declaringMethod));
+        queryParameters.add(new RealMethodParameter(parameter, i, queryParamAnnotation, MethodParameterType.Query, declaringMethod));
         continue;
       }
       final AnnotationDesc cookieParamAnnotation = Utils.findParameterAnnotation(declaringMethod, parameter, i, CookieParam.class);
       if (cookieParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(cookieParamAnnotation);
-        cookieParameters.put(name,
-                             new RealMethodParameter(parameter, i, cookieParamAnnotation, MethodParameterType.Cookie, declaringMethod));
+        cookieParameters.add(new RealMethodParameter(parameter, i, cookieParamAnnotation, MethodParameterType.Cookie, declaringMethod));
         continue;
       }
       final AnnotationDesc formParamAnnotation = Utils.findParameterAnnotation(declaringMethod, parameter, i, FormParam.class);
       if (formParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(formParamAnnotation);
-        formParameters.put(name, new RealMethodParameter(parameter, i, formParamAnnotation, MethodParameterType.Form, declaringMethod));
+        formParameters.add(new RealMethodParameter(parameter, i, formParamAnnotation, MethodParameterType.Form, declaringMethod));
         continue;
       }
       final AnnotationDesc headerParamAnnotation = Utils.findParameterAnnotation(declaringMethod, parameter, i, HeaderParam.class);
       if (headerParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(headerParamAnnotation);
-        headerParameters.put(name,
-                             new RealMethodParameter(parameter, i, headerParamAnnotation, MethodParameterType.Header, declaringMethod));
+        headerParameters.add(new RealMethodParameter(parameter, i, headerParamAnnotation, MethodParameterType.Header, declaringMethod));
         continue;
       }
       if (formClass != null) {
@@ -197,37 +195,35 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
       final AnnotationDesc pathParamAnnotation = Utils.findAnnotation(field, PathParam.class);
       if (pathParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(pathParamAnnotation);
-        pathParameters.put(name, new FormFieldParameter(field, pathParamAnnotation, MethodParameterType.Path));
+        pathParameters.add(new FormFieldParameter(field, pathParamAnnotation, MethodParameterType.Path));
         continue;
       }
       final AnnotationDesc matrixParamAnnotation = Utils.findAnnotation(field, MatrixParam.class);
       if (matrixParamAnnotation != null) {
-        String name = (String) Utils.getAnnotationValue(matrixParamAnnotation);
-        matrixParameters.put(name, new FormFieldParameter(field, matrixParamAnnotation, MethodParameterType.Matrix));
+        matrixParameters.add(new FormFieldParameter(field, matrixParamAnnotation, MethodParameterType.Matrix));
         continue;
       }
       final AnnotationDesc queryParamAnnotation = Utils.findAnnotation(field, QueryParam.class);
       if (queryParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(queryParamAnnotation);
-        queryParameters.put(name, new FormFieldParameter(field, queryParamAnnotation, MethodParameterType.Query));
+        queryParameters.add(new FormFieldParameter(field, queryParamAnnotation, MethodParameterType.Query));
         continue;
       }
       final AnnotationDesc headerParamAnnotation = Utils.findAnnotation(field, HeaderParam.class);
       if (headerParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(headerParamAnnotation);
-        headerParameters.put(name, new FormFieldParameter(field, headerParamAnnotation, MethodParameterType.Header));
+        headerParameters.add(new FormFieldParameter(field, headerParamAnnotation, MethodParameterType.Header));
         continue;
       }
       final AnnotationDesc cookieParamAnnotation = Utils.findAnnotation(field, CookieParam.class);
       if (cookieParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(cookieParamAnnotation);
-        cookieParameters.put(name, new FormFieldParameter(field, cookieParamAnnotation, MethodParameterType.Cookie));
+        cookieParameters.add(new FormFieldParameter(field, cookieParamAnnotation, MethodParameterType.Cookie));
         continue;
       }
       final AnnotationDesc formParamAnnotation = Utils.findAnnotation(field, FormParam.class);
       if (formParamAnnotation != null) {
-        String name = (String) Utils.getAnnotationValue(formParamAnnotation);
-        formParameters.put(name, new FormFieldParameter(field, formParamAnnotation, MethodParameterType.Form));
+        formParameters.add(new FormFieldParameter(field, formParamAnnotation, MethodParameterType.Form));
         continue;
       }
       final AnnotationDesc contextAnnotation = Utils.findAnnotation(field, Context.class);
@@ -243,37 +239,37 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
       final AnnotationDesc pathParamAnnotation = Utils.findParameterAnnotation(method, parameter, 0, PathParam.class);
       if (pathParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(pathParamAnnotation);
-        pathParameters.put(name, new FormMethodParameter(method, pathParamAnnotation, MethodParameterType.Path));
+        pathParameters.add(new FormMethodParameter(method, pathParamAnnotation, MethodParameterType.Path));
         continue;
       }
       final AnnotationDesc matrixParamAnnotation = Utils.findParameterAnnotation(method, parameter, 0, MatrixParam.class);
       if (matrixParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(matrixParamAnnotation);
-        matrixParameters.put(name, new FormMethodParameter(method, matrixParamAnnotation, MethodParameterType.Matrix));
+        matrixParameters.add(new FormMethodParameter(method, matrixParamAnnotation, MethodParameterType.Matrix));
         continue;
       }
       final AnnotationDesc queryParamAnnotation = Utils.findParameterAnnotation(method, parameter, 0, QueryParam.class);
       if (queryParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(queryParamAnnotation);
-        queryParameters.put(name, new FormMethodParameter(method, queryParamAnnotation, MethodParameterType.Query));
+        queryParameters.add(new FormMethodParameter(method, queryParamAnnotation, MethodParameterType.Query));
         continue;
       }
       final AnnotationDesc headerParamAnnotation = Utils.findParameterAnnotation(method, parameter, 0, HeaderParam.class);
       if (headerParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(headerParamAnnotation);
-        headerParameters.put(name, new FormMethodParameter(method, headerParamAnnotation, MethodParameterType.Header));
+        headerParameters.add(new FormMethodParameter(method, headerParamAnnotation, MethodParameterType.Header));
         continue;
       }
       final AnnotationDesc cookieParamAnnotation = Utils.findParameterAnnotation(method, parameter, 0, CookieParam.class);
       if (cookieParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(cookieParamAnnotation);
-        cookieParameters.put(name, new FormMethodParameter(method, cookieParamAnnotation, MethodParameterType.Cookie));
+        cookieParameters.add(new FormMethodParameter(method, cookieParamAnnotation, MethodParameterType.Cookie));
         continue;
       }
       final AnnotationDesc formParamAnnotation = Utils.findParameterAnnotation(method, parameter, 0, FormParam.class);
       if (formParamAnnotation != null) {
         String name = (String) Utils.getAnnotationValue(formParamAnnotation);
-        formParameters.put(name, new FormMethodParameter(method, formParamAnnotation, MethodParameterType.Form));
+        formParameters.add(new FormMethodParameter(method, formParamAnnotation, MethodParameterType.Form));
         continue;
       }
       final AnnotationDesc contextAnnotation = Utils.findParameterAnnotation(method, parameter, 0, Context.class);
@@ -299,7 +295,7 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
   }
 
   public String toString() {
-    StringBuffer strbuf = new StringBuffer(path);
+    StringBuilder strbuf = new StringBuilder(path);
     strbuf.append(" ");
     for (AnnotationDesc method : methods) {
       strbuf.append(method.annotationType().name());
@@ -317,23 +313,21 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
   }
 
   public List<String> getProduces() {
-    if (getProducesAnnotation() == null)
+    AnnotationDesc produces = getProducesAnnotation();
+    if (produces == null) {
       return Collections.emptyList();
-    List<String> producedMIMEs = new ArrayList<String>();
-    for (String mime : Utils.getAnnotationValues(getProducesAnnotation())) {
-      producedMIMEs.add(mime);
+    } else {
+      return Arrays.asList(Utils.getAnnotationValues(produces));
     }
-    return producedMIMEs;
   }
 
   public List<String> getConsumes() {
-    if (getConsumesAnnotation() == null)
+    AnnotationDesc consumes = getConsumesAnnotation();
+    if (consumes == null) {
       return Collections.emptyList();
-    List<String> consumedMIMEs = new ArrayList<String>();
-    for (String mime : Utils.getAnnotationValues(getConsumesAnnotation())) {
-      consumedMIMEs.add(mime);
+    } else {
+      return Arrays.asList(Utils.getAnnotationValues(consumes));
     }
-    return consumedMIMEs;
   }
 
   public MethodDoc getJavaDoc() {
@@ -348,59 +342,59 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
     return declaringMethod.firstSentenceTags();
   }
 
-  public Map<String, MethodParameter> getQueryParameters() {
+  public List<MethodParameter> getQueryParameters() {
     if (resource.isSubResource()) {
-      Map<String, MethodParameter> allQueryParameters = new HashMap<String, MethodParameter>(resource.getParentMethod()
+      List<MethodParameter> allQueryParameters = new ArrayList<MethodParameter>(resource.getParentMethod()
           .getQueryParameters());
-      allQueryParameters.putAll(queryParameters);
+      allQueryParameters.addAll(queryParameters);
       return allQueryParameters;
     }
     return queryParameters;
   }
 
-  public Map<String, MethodParameter> getPathParameters() {
+  public List<MethodParameter> getPathParameters() {
     if (resource.isSubResource()) {
-      Map<String, MethodParameter> allPathParameters = new HashMap<String, MethodParameter>(resource.getParentMethod().getPathParameters());
-      allPathParameters.putAll(pathParameters);
+      List<MethodParameter> allPathParameters = new ArrayList<MethodParameter>(resource.getParentMethod().getPathParameters());
+      allPathParameters.addAll(pathParameters);
       return allPathParameters;
     }
     return pathParameters;
   }
 
-  public Map<String, MethodParameter> getMatrixParameters() {
+  public List<MethodParameter> getMatrixParameters() {
     if (resource.isSubResource()) {
-      Map<String, MethodParameter> allMatrixParameters = new HashMap<String, MethodParameter>(resource.getParentMethod()
+      List<MethodParameter> allMatrixParameters = new ArrayList<MethodParameter>(resource.getParentMethod()
           .getMatrixParameters());
-      allMatrixParameters.putAll(matrixParameters);
+      allMatrixParameters.addAll(matrixParameters);
       return allMatrixParameters;
     }
     return matrixParameters;
   }
 
-  public Map<String, MethodParameter> getCookieParameters() {
+  public List<MethodParameter> getCookieParameters() {
     if (resource.isSubResource()) {
-      Map<String, MethodParameter> allCookieParameters = new HashMap<String, MethodParameter>(resource.getParentMethod()
+      List<MethodParameter> allCookieParameters = new ArrayList<MethodParameter>(resource.getParentMethod()
           .getCookieParameters());
-      allCookieParameters.putAll(cookieParameters);
+      allCookieParameters.addAll(cookieParameters);
       return allCookieParameters;
     }
     return cookieParameters;
   }
 
-  public Map<String, MethodParameter> getHeaderParameters() {
+  public List<MethodParameter> getHeaderParameters() {
     if (resource.isSubResource()) {
-      Map<String, MethodParameter> allHeaderParameters = new HashMap<String, MethodParameter>(resource.getParentMethod()
+      List<MethodParameter> allHeaderParameters = new ArrayList<MethodParameter>(resource.getParentMethod()
           .getHeaderParameters());
-      allHeaderParameters.putAll(headerParameters);
+      allHeaderParameters.addAll(headerParameters);
       return allHeaderParameters;
     }
     return headerParameters;
   }
 
-  public Map<String, MethodParameter> getFormParameters() {
+  public List<MethodParameter> getFormParameters() {
     if (resource.isSubResource()) {
-      Map<String, MethodParameter> allFormParameters = new HashMap<String, MethodParameter>(resource.getParentMethod().getFormParameters());
-      allFormParameters.putAll(formParameters);
+      List<MethodParameter> allFormParameters = new ArrayList<MethodParameter>(resource.getParentMethod().getFormParameters());
+      allFormParameters.addAll(formParameters);
       return allFormParameters;
     }
     return formParameters;
@@ -423,26 +417,24 @@ public class ResourceMethod implements Comparable<ResourceMethod> {
   }
 
   public String getURL(Resource resource) {
-    StringBuffer strbuf = new StringBuffer(resource.getAbsolutePath());
-    Map<String, MethodParameter> matrixParameters = getMatrixParameters();
-    if (!matrixParameters.isEmpty()) {
-      for (String name : matrixParameters.keySet()) {
-        strbuf.append(";");
-        strbuf.append(name);
-        strbuf.append("=…");
-      }
+    StringBuilder strbuf = new StringBuilder(resource.getAbsolutePath());
+
+    for (MethodParameter parameter : getMatrixParameters()) {
+      strbuf.append(";");
+      strbuf.append(parameter.getName());
+      strbuf.append("=…");
     }
-    Map<String, MethodParameter> queryParameters = getQueryParameters();
-    if (!queryParameters.isEmpty()) {
-      strbuf.append("?");
-      boolean first = true;
-      for (String name : queryParameters.keySet()) {
-        if (!first)
-          strbuf.append("&amp;");
-        strbuf.append(name);
-        strbuf.append("=…");
-        first = false;
+
+    boolean first = true;
+    for (MethodParameter parameter : getQueryParameters()) {
+      if(first) {
+        strbuf.append("?");
+      } else {
+        strbuf.append("&amp;");
       }
+      strbuf.append(parameter.getName());
+      strbuf.append("=…");
+      first = false;
     }
     return strbuf.toString();
   }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/tags/ExcludeTaglet.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/tags/ExcludeTaglet.java
@@ -1,0 +1,99 @@
+/*
+    Copyright 2009 Lunatech Research
+
+    This file is part of jax-doclets.
+
+    jax-doclets is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    jax-doclets is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with jax-doclets.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.lunatech.doclets.jax.jaxrs.tags;
+
+import java.util.Map;
+
+import com.sun.javadoc.Doc;
+import com.sun.javadoc.Tag;
+import com.sun.tools.doclets.internal.toolkit.taglets.Taglet;
+import com.sun.tools.doclets.internal.toolkit.taglets.TagletOutput;
+import com.sun.tools.doclets.internal.toolkit.taglets.TagletWriter;
+
+public class ExcludeTaglet implements Taglet {
+
+  public static final String NAME = "exclude";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public boolean inField() {
+    return true;
+  }
+
+  @Override
+  public boolean inConstructor() {
+    return true;
+  }
+
+  @Override
+  public boolean inMethod() {
+    return true;
+  }
+
+  @Override
+  public boolean inOverview() {
+    return true;
+  }
+
+  @Override
+  public boolean inPackage() {
+    return true;
+  }
+
+  @Override
+  public boolean inType() {
+    return true;
+  }
+
+  @Override
+  public boolean isInlineTag() {
+    return false;
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public static void register(Map tagletMap) {
+    ExcludeTaglet tag = new ExcludeTaglet();
+    Taglet t = (Taglet) tagletMap.get(tag.getName());
+    if (t != null) {
+      tagletMap.remove(tag.getName());
+    }
+    tagletMap.put(tag.getName(), tag);
+  }
+
+  /**
+   * Exclude tag does not support output.
+   */
+  @Override
+  public TagletOutput getTagletOutput(Tag tag, TagletWriter writer) throws IllegalArgumentException {
+    throw new IllegalArgumentException();
+  }
+
+  /**
+   * Exclude tag does not support output.
+   */
+  @Override
+  public TagletOutput getTagletOutput(Doc doc, TagletWriter writer) throws IllegalArgumentException {
+    throw new IllegalArgumentException();
+  }
+
+}

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -21,7 +21,6 @@ package com.lunatech.doclets.jax.jaxrs.writers;
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import com.lunatech.doclets.jax.Utils;

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/MethodWriter.java
@@ -294,13 +294,13 @@ public class MethodWriter extends DocletWriter {
     close("dd");
   }
 
-  private void printParameters(Map<String, MethodParameter> parameters, String header) {
+  private void printParameters(List<MethodParameter> parameters, String header) {
     if (parameters.isEmpty())
       return;
     open("dt");
     around("b", header + " parameters:");
     close("dt");
-    for (MethodParameter param : parameters.values()) {
+    for (MethodParameter param : parameters) {
       open("dd");
       around("b", param.getName());
       String doc = param.getDoc();
@@ -349,9 +349,9 @@ public class MethodWriter extends DocletWriter {
     close("p");
   }
 
-  private boolean printAPIParameters(Map<String, MethodParameter> parameters, boolean hasOne) {
-    for (String name : parameters.keySet()) {
-      printAPIParameter(name, parameters.get(name), hasOne);
+  private boolean printAPIParameters(List<MethodParameter> parameters, boolean hasOne) {
+    for (MethodParameter parameter : parameters) {
+      printAPIParameter(parameter.getName(), parameter, hasOne);
       hasOne = true;
     }
     return hasOne;
@@ -382,55 +382,49 @@ public class MethodWriter extends DocletWriter {
     String absPath = Utils.getAbsolutePath(this, resource);
 
     print(httpMethod + " " + absPath);
-    Map<String, MethodParameter> matrixParameters = method.getMatrixParameters();
+    List<MethodParameter> matrixParameters = method.getMatrixParameters();
     if (!matrixParameters.isEmpty()) {
-      for (String name : matrixParameters.keySet()) {
+      for (MethodParameter parameter : matrixParameters) {
         print(";");
-        print(name);
+        print(parameter.getName());
         print("=…");
       }
     }
-    Map<String, MethodParameter> queryParameters = method.getQueryParameters();
+    List<MethodParameter> queryParameters = method.getQueryParameters();
     if (!queryParameters.isEmpty()) {
       print("?");
       boolean first = true;
-      for (String name : queryParameters.keySet()) {
+      for (MethodParameter parameter : queryParameters) {
         if (!first)
           print("&amp;");
-        print(name);
+        print(parameter.getName());
         print("=…");
         first = false;
       }
     }
     print("\n");
 
-    Map<String, MethodParameter> headerParameters = method.getHeaderParameters();
-    if (!headerParameters.isEmpty()) {
-      for (String name : headerParameters.keySet()) {
-        print(name);
-        print(": …\n");
-      }
-    }
-    Map<String, MethodParameter> cookieParameters = method.getCookieParameters();
-    if (!cookieParameters.isEmpty()) {
-      for (String name : cookieParameters.keySet()) {
-        print("Cookie: ");
-        print(name);
-        print("=…\n");
-      }
+    for (MethodParameter parameter : method.getHeaderParameters()) {
+      print(parameter.getName());
+      print(": …\n");
     }
 
-    Map<String, MethodParameter> formParameters = method.getFormParameters();
-    if (!formParameters.isEmpty()) {
-      print("\n");
-      boolean first = true;
-      for (String name : formParameters.keySet()) {
-        if (!first)
-          print("&amp;");
-        print(name);
-        print("=…");
-        first = false;
+    for (MethodParameter parameter : method.getCookieParameters()) {
+      print("Cookie: ");
+      print(parameter.getName());
+      print("=…\n");
+    }
+
+    boolean first = true;
+    for (MethodParameter parameter : method.getFormParameters()) {
+      if(first) {
+        print("\n");
+      } else {
+        print("&amp;");
       }
+      print(parameter.getName());
+      print("=…");
+      first = false;
     }
     print("\n");
     close("pre");

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/writers/ResourceWriter.java
@@ -219,8 +219,7 @@ public class ResourceWriter extends DocletWriter {
       }
       // All methods on same resource, so path should be same
       ResourceMethod rm = lrm.get(0);
-      Map<String, MethodParameter> parameters = rm.getPathParameters();
-      for (MethodParameter param : parameters.values()) {
+      for (MethodParameter param : rm.getPathParameters()) {
         if (needsPathHeading) {
           open("dl");
           open("dt");

--- a/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
+++ b/docs/src/main/wikbook/en/en-US/JAXRSDoclet.wiki
@@ -34,6 +34,7 @@ The following specific JavaDoc tags are supported on resource methods:
 |{{@RequestHeader \{header\} \{doc\} }}|This is used to document HTTP request headers. Can be used multiple times.|
 |{{@ResponseHeader \{header\} \{doc\} }}|This is used to document HTTP response headers. Can be used multiple times.|
 |{{@include \{file\} }}|Includes the specified relative file in the resource documentation. Can be used multiple times.|
+|{{@exclude}}|Excludes the annotated method or resource from generated documentation. If a resource is excluded, none of its methods will appear in the documentation either.|
 
 h2. Supported JAX-RS annotations
 


### PR DESCRIPTION
I changed the parameter info to be stored in Lists instead of Maps so we get it in the same order it was defined in. The previous version displayed parameters in arbitrary order, and we never look up parameters by name anyway.

Are the size of my pull requests ok or would prefer that I do them in larger chunks?
