### PR TITLE
Feature #47: Support for @ApplicationPath in JAX-RS doclet

### DIFF
--- a/doclets/pom.xml
+++ b/doclets/pom.xml
@@ -138,7 +138,7 @@
 	 							<docletArtifact>
 									<groupId>javax.ws.rs</groupId>
 									<artifactId>jsr311-api</artifactId>
-									<version>1.1</version> 							
+									<version>1.1.1</version>
  								</docletArtifact>
  							</docletArtifacts>
 							<destDir>jpadocs</destDir>
@@ -203,7 +203,7 @@
 	 							<docletArtifact>
 									<groupId>javax.ws.rs</groupId>
 									<artifactId>jsr311-api</artifactId>
-									<version>1.1</version> 							
+									<version>1.1.1</version>
  								</docletArtifact>
  								<docletArtifact>
 									<groupId>org.jboss.resteasy</groupId>
@@ -220,7 +220,7 @@
 					<dependency>
 						<groupId>javax.ws.rs</groupId>
 						<artifactId>jsr311-api</artifactId>
-						<version>1.1</version>
+						<version>1.1.1</version>
 					</dependency>
 	 				<dependency>
 						<groupId>org.hibernate.javax.persistence</groupId>

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceClass.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/ResourceClass.java
@@ -42,6 +42,8 @@ public class ResourceClass {
 
   private ClassDoc declaringClass;
 
+  private String applicationRootPath;
+
   private AnnotationDesc rootPathAnnotation;
 
   private AnnotationDesc rootProducesAnnotation;
@@ -55,7 +57,12 @@ public class ResourceClass {
   private Map<String, String> regexFragments = new HashMap<String, String>();
 
   public ResourceClass(ClassDoc resourceClass, ResourceMethod methodLocator) {
+    this(resourceClass, methodLocator, null);
+  }
+
+  public ResourceClass(ClassDoc resourceClass, ResourceMethod methodLocator, String applicationRootPath) {
     this.parentMethod = methodLocator;
+    this.applicationRootPath = applicationRootPath;
     // find the annotated class or interface
     declaringClass = Utils.findAnnotatedClass(resourceClass, Path.class);
     // sub-resources may not have a path, but they're still resources
@@ -104,6 +111,8 @@ public class ResourceClass {
       path = null;
     if (parentMethod != null)
       path = Utils.appendURLFragments(parentMethod.getPath(), path);
+    if (parentMethod == null && applicationRootPath != null)
+      path = Utils.appendURLFragments("/", applicationRootPath, path);
   }
 
   public ClassDoc getDeclaringClass() {

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 			<dependency>
 				<groupId>javax.ws.rs</groupId>
 				<artifactId>jsr311-api</artifactId>
-				<version>1.1</version>
+				<version>1.1.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Added support for @ApplicationPath in JAX-RS

```
Fixed #47 "Support for @ApplicationPath in JAX-RS doclet"
Now application path from javax.ws.rs.core.Application child prepended
to resources.
```
