### PR TITLE
Support {@docRoot} tag for header and footer

### DIFF
--- a/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/writers/DocletWriter.java
@@ -93,7 +93,7 @@ public class DocletWriter {
     open("BODY");
     String msg = configuration.parentConfiguration.header;
     if (msg != null) {
-      print(msg);
+      print(writer.replaceDocRootDir(msg));
     }
   }
 
@@ -102,7 +102,7 @@ public class DocletWriter {
   protected void printFooter() {
     String msg = configuration.parentConfiguration.footer;
     if (msg != null) {
-      print(msg);
+      print(writer.replaceDocRootDir(msg));
     }
     tag("hr");
     open("div class='footer'");

--- a/docs/src/main/wikbook/en/en-US/running.wiki
+++ b/docs/src/main/wikbook/en/en-US/running.wiki
@@ -207,8 +207,8 @@ These parameters are valid for all jax-doclets
 
 ||Parameter||Function||
 |{{-stylesheet}}|The CSS stylesheet to copy and use.|
-|{{-header}}|The header which is inserted on every page header.|
-|{{-footer}}|The footer which is inserted on every page footer.|
+|{{-header}}|The header which is inserted on every page header ([{@docRoot}|http://docs.oracle.com/javase/1.5.0/docs/tooldocs/solaris/javadoc.html#{@docRoot}] is supported).|
+|{{-footer}}|The footer which is inserted on every page footer ([{@docRoot}|http://docs.oracle.com/javase/1.5.0/docs/tooldocs/solaris/javadoc.html#{@docRoot}] is supported).|
 |{{-charset}}|The charset to use for source files and produced HTML documentation.|
 |{{-link}}{anchor:id=-link}|Path to another JavaDoc documentation. This is used to produce links to other package's documentation, either regular JavaDoc or to JAXB documentation in the case of the JAX-RS doclet.|
 |{{-nonavbar}}|Prevents the generation of the navigation bar.|


### PR DESCRIPTION
The {@docRoot} tag is replaced by the relative path to the documentation root
directory. It allows to include images placed at the root even if documentation
pages are nested in several folders.

It will be replaced if found in header and footer text.
