### PR TITLE
jaxb: Exclude transient and @XmlTransient members

### DIFF
--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxb/model/JAXBClass.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxb/model/JAXBClass.java
@@ -143,7 +143,7 @@ public class JAXBClass implements Comparable<JAXBClass> {
       break;
     case PUBLIC_MEMBER:
       // all public or annotated members
-      include = (property.isPublic() || hasXmlAnnotation) && (this.doclet.conf.enableJaxBMethodOutput || !property.isMethod());
+      include = (property.isPublic() || hasXmlAnnotation) && (this.doclet.conf.enableJaxBMethodOutput || !property.isMethod()) && !isTransient;
       break;
     }
     if (include)

--- a/doclets/src/test/java/com/lunatech/doclets/jax/jaxb/testcase/ClassExample.java
+++ b/doclets/src/test/java/com/lunatech/doclets/jax/jaxb/testcase/ClassExample.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlList;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 
 @XmlRootElement
 public class ClassExample {
@@ -89,4 +90,11 @@ public class ClassExample {
   public void setStringCollection(Collection<String> stringCollection) {
     this.stringCollection = stringCollection;
   }
+
+  public String nonTransientField;
+
+  public transient String transientField;
+
+  @XmlTransient
+  public String xmlTransientField;
 }

--- a/docs/src/main/wikbook/en/en-US/JAXBDoclet.wiki
+++ b/docs/src/main/wikbook/en/en-US/JAXBDoclet.wiki
@@ -31,7 +31,7 @@ The following standard JAXB annotations are supported on properties or classes:
 * {{@XmlValue}}
 * {{@XmlID}}
 * {{@XmlIDREF}}
-* {{@XmlTransient}} (ignored)
+* {{@XmlTransient}}
     
 h2. Mapping Java types to XML tpes
 


### PR DESCRIPTION
Small fix to support @XmlTransient on public members. Also updated the doc accordingly.
