### PR TITLE
Enable generating JAX-RS documentation from interface.

### DIFF
--- a/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/Utils.java
@@ -226,22 +226,28 @@ public class Utils {
   }
 
   public static ClassDoc findAnnotatedClass(final ClassDoc klass, final Class<?>... soughtAnnotations) {
-    if (!klass.isClass() || isExcluded(klass))
+    if (!klass.isClass())
       return null;
-    if (hasAnnotation(klass, soughtAnnotations)) {
-      return klass;
-    }
-    // find it in the interfaces
-    final ClassDoc foundClassDoc = findAnnotatedInterface(klass, soughtAnnotations);
-    if (foundClassDoc != null) {
-      return foundClassDoc;
-    }
+    return findAnnotatedClassOrInterface(klass, soughtAnnotations);
+  }
 
-    final Type superclass = klass.superclassType();
-    if (superclass != null && superclass.asClassDoc() != null) {
-      return findAnnotatedClass(superclass.asClassDoc(), soughtAnnotations);
-    }
-    return null;
+  public static ClassDoc findAnnotatedClassOrInterface(ClassDoc klass, Class<?>... soughtAnnotations) {
+	  if (isExcluded(klass))
+		  return null;
+	    if (hasAnnotation(klass, soughtAnnotations)) {
+	        return klass;
+	      }
+	      // find it in the interfaces
+	      final ClassDoc foundClassDoc = findAnnotatedInterface(klass, soughtAnnotations);
+	      if (foundClassDoc != null) {
+	        return foundClassDoc;
+	      }
+
+	      final Type superclass = klass.superclassType();
+	      if (superclass != null && superclass.asClassDoc() != null) {
+	        return findAnnotatedClass(superclass.asClassDoc(), soughtAnnotations);
+	      }
+	      return null;
   }
 
   public static Type findSuperType(final Type type, String typeName) {
@@ -894,4 +900,5 @@ public class Utils {
   private static boolean isExcluded(Doc doc) {
       return doc.tags("exclude").length != 0;
   }
+
 }

--- a/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
+++ b/doclets/src/main/java/com/lunatech/doclets/jax/jaxrs/model/JAXRSApplication.java
@@ -1,5 +1,6 @@
 package com.lunatech.doclets.jax.jaxrs.model;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -33,7 +34,8 @@ public class JAXRSApplication {
   private void discoverJAXRSResources() {
     final ClassDoc[] classes = conf.parentConfiguration.root.classes();
     for (final ClassDoc klass : classes) {
-      if (Utils.findAnnotatedClass(klass, jaxrsAnnotations) != null) {
+    	
+      if (Utils.findAnnotatedClassOrInterface(klass, jaxrsAnnotations) != null) {
         handleJAXRSClass(klass);
       }
     }


### PR DESCRIPTION
This patch allows for generating jax-rs documentation based on an annotated interface instead of an implementing class.
